### PR TITLE
feature: Convert to async/await

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 *.iml
 .vscode/
 CouchbaseMock.jar
+tags

--- a/couchbase/Cargo.toml
+++ b/couchbase/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/couchbase"
 
 [dependencies]
 couchbase-sys = { path = "../couchbase-sys", version = "=1.0.0-alpha.3" }
-futures = "0.1"
+futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/couchbase/examples/analytics_simple.rs
+++ b/couchbase/examples/analytics_simple.rs
@@ -19,7 +19,7 @@ fn main() {
         println!(
             "---> rows {:?}",
             result
-                .rows_as()
+                .rows_as().expect("Rows already consumed")
                 .collect::<Vec<Result<Value, CouchbaseError>>>().await
         );
         println!(

--- a/couchbase/examples/analytics_simple.rs
+++ b/couchbase/examples/analytics_simple.rs
@@ -1,5 +1,6 @@
 use couchbase::{Cluster, CouchbaseError};
-use futures::{Future, Stream};
+use futures::stream::StreamExt;
+use futures::executor::block_on;
 use serde_json::Value;
 
 fn main() {
@@ -9,22 +10,24 @@ fn main() {
         .expect("Could not create cluster reference!");
     let _ = cluster.bucket("travel-sample");
 
-    let mut result = cluster
-        .analytics_query("SELECT DataverseName FROM Metadata.`Dataverse`", None)
-        .wait()
-        .expect("Could not perform analytics query");
+    let f = async {
+        let mut result = cluster
+            .analytics_query("SELECT DataverseName FROM Metadata.`Dataverse`", None)
+            .await
+            .expect("Could not perform analytics query");
 
-    println!(
-        "---> rows {:?}",
-        result
-            .rows_as()
-            .wait()
-            .collect::<Vec<Result<Value, CouchbaseError>>>()
-    );
-    println!(
-        "---> meta {:?}",
-        result.meta().wait().expect("Could not get analytics meta")
-    );
+        println!(
+            "---> rows {:?}",
+            result
+                .rows_as()
+                .collect::<Vec<Result<Value, CouchbaseError>>>().await
+        );
+        println!(
+            "---> meta {:?}",
+            result.meta().await.expect("Could not get analytics meta")
+        );
 
-    cluster.disconnect().expect("Could not shutdown properly");
+        cluster.disconnect().expect("Could not shutdown properly");
+    };
+    block_on(f);
 }

--- a/couchbase/examples/kv_basics.rs
+++ b/couchbase/examples/kv_basics.rs
@@ -1,5 +1,5 @@
 use couchbase::Cluster;
-use futures::Future;
+use futures::executor::block_on;
 use serde_derive::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -18,40 +18,42 @@ fn main() {
         .expect("Could not open bucket");
     let collection = bucket.default_collection();
 
-    let found_doc = collection
-        .get("airport_1297", None)
-        .wait()
-        .expect("Error while loading doc");
-    println!("Airline Document: {:?}", found_doc);
-    println!(
-        "Content Decoded {:?}",
-        found_doc.content_as::<Airport>()
-    );
+    let f = async {
+        let found_doc = collection
+            .get("airport_1297", None)
+            .await
+            .expect("Error while loading doc");
+        println!("Airline Document: {:?}", found_doc);
+        println!(
+            "Content Decoded {:?}",
+            found_doc.content_as::<Airport>()
+        );
 
-    println!(
-        "Document does exist?: {:?}",
-        collection.exists("airport_1297", None).wait()
-    );
+        println!(
+            "Document does exist?: {:?}",
+            collection.exists("airport_1297", None).await
+        );
 
-    println!(
-        "Airline Document: {:?}",
-        collection.get("enoent", None).wait()
-    );
+        println!(
+            "Airline Document: {:?}",
+            collection.get("enoent", None).await
+        );
 
-    println!("Upsert: {:?}", collection.upsert("foo", "bar", None).wait());
-    println!("Get: {:?}", collection.get("foo", None).wait());
+        println!("Upsert: {:?}", collection.upsert("foo", "bar", None).await);
+        println!("Get: {:?}", collection.get("foo", None).await);
 
-    println!("Remove: {:?}", collection.remove("foo", None).wait());
-    println!("Get: {:?}", collection.get("foo", None).wait());
+        println!("Remove: {:?}", collection.remove("foo", None).await);
+        println!("Get: {:?}", collection.get("foo", None).await);
 
-    println!(
-        "First Insert: {:?}",
-        collection.insert("bla", "bla", None).wait()
-    );
-    println!(
-        "Second Insert: {:?}",
-        collection.insert("bla", "bla", None).wait()
-    );
-
-    cluster.disconnect().expect("Could not shutdown properly");
+        println!(
+            "First Insert: {:?}",
+            collection.insert("bla", "bla", None).await
+        );
+        println!(
+            "Second Insert: {:?}",
+            collection.insert("bla", "bla", None).await
+        );
+        cluster.disconnect().expect("Could not shutdown properly");
+    };
+    block_on(f);
 }

--- a/couchbase/examples/kv_mutate.rs
+++ b/couchbase/examples/kv_mutate.rs
@@ -1,5 +1,5 @@
 use couchbase::Cluster;
-use futures::Future;
+use futures::executor::block_on;
 use serde_derive::Serialize;
 use std::time::Duration;
 
@@ -25,15 +25,18 @@ fn main() {
         icao: "LOWW".into(),
         iata: "VIE".into(),
     };
-    collection
-        .upsert("airport_999", airport, None)
-        .wait()
-        .expect("could not upsert airport!");
+    let f = async {
+        collection
+            .upsert("airport_999", airport, None)
+            .await
+            .expect("could not upsert airport!");
 
-    collection
-        .touch("airport_999", Duration::from_secs(5), None)
-        .wait()
-        .expect("Can't touch this!");
+        collection
+            .touch("airport_999", Duration::from_secs(5), None)
+            .await
+            .expect("Can't touch this!");
 
-    cluster.disconnect().expect("Failure while disconnecting!");
+        cluster.disconnect().expect("Failure while disconnecting!");
+    };
+    block_on(f);
 }

--- a/couchbase/examples/kv_subdoc_lookup.rs
+++ b/couchbase/examples/kv_subdoc_lookup.rs
@@ -1,6 +1,6 @@
 use couchbase::subdoc::LookupInSpec;
 use couchbase::Cluster;
-use futures::Future;
+use futures::executor::block_on;
 
 fn main() {
     env_logger::init();
@@ -12,19 +12,22 @@ fn main() {
         .expect("Could not open bucket");
     let collection = bucket.default_collection();
 
-    // Fetch only a partial list of fields
-    let partial_result = collection
-        .lookup_in("airport_1285", vec![LookupInSpec::get("geo")], None)
-        .wait();
-    println!("Partial Result: {:?}", partial_result);
+    let f = async {
+        // Fetch only a partial list of fields
+        let partial_result = collection
+            .lookup_in("airport_1285", vec![LookupInSpec::get("geo")], None)
+            .await;
+        println!("Partial Result: {:?}", partial_result);
 
-    // Fetch the full document (might be needed in combination with xattrs or macros)
-    let full_result = collection
-        .lookup_in(
-            "airline_10123",
-            vec![LookupInSpec::get_full_document()],
-            None,
-        )
-        .wait();
-    println!("Full Result: {:?}", full_result);
+        // Fetch the full document (might be needed in combination with xattrs or macros)
+        let full_result = collection
+            .lookup_in(
+                "airline_10123",
+                vec![LookupInSpec::get_full_document()],
+                None,
+            )
+            .await;
+        println!("Full Result: {:?}", full_result);
+    };
+    block_on(f);
 }

--- a/couchbase/examples/kv_subdoc_mutate.rs
+++ b/couchbase/examples/kv_subdoc_mutate.rs
@@ -1,6 +1,6 @@
 use couchbase::subdoc::MutateInSpec;
 use couchbase::Cluster;
-use futures::Future;
+use futures::executor::block_on;
 
 fn main() {
     env_logger::init();
@@ -12,13 +12,16 @@ fn main() {
         .expect("Could not open bucket");
     let collection = bucket.default_collection();
 
-    // Add field to document
-    let insert_result = collection
-        .mutate_in(
-            "airport_1285",
-            vec![MutateInSpec::upsert("updated", true).expect("could not encode value")],
-            None,
-        )
-        .wait();
-    println!("Insert Result: {:?}", insert_result);
+    let f = async {
+        // Add field to document
+        let insert_result = collection
+            .mutate_in(
+                "airport_1285",
+                vec![MutateInSpec::upsert("updated", true).expect("could not encode value")],
+                None,
+            )
+            .await;
+        println!("Insert Result: {:?}", insert_result);
+    };
+    block_on(f);
 }

--- a/couchbase/examples/query_decoding.rs
+++ b/couchbase/examples/query_decoding.rs
@@ -29,7 +29,7 @@ fn main() {
         println!(
             "---> rows {:?}",
             result
-                .rows_as()
+                .rows_as().expect("Rows already consumed")
                 .collect::<Vec<Result<Airport, CouchbaseError>>>().await
         );
         println!(

--- a/couchbase/examples/query_parameters.rs
+++ b/couchbase/examples/query_parameters.rs
@@ -1,7 +1,9 @@
 use couchbase::options::QueryOptions;
 use couchbase::{Cluster, CouchbaseError};
-use futures::{Future, Stream};
+use futures::executor::block_on;
+use futures::stream::StreamExt;
 use serde_json::{json, Value};
+
 use std::collections::HashMap;
 
 fn main() {
@@ -11,42 +13,43 @@ fn main() {
         .expect("Could not create cluster reference");
     let _ = cluster.bucket("travel-sample");
 
-    let positional_options =
-        QueryOptions::new().set_positional_parameters(vec![json!("Texas Wings")]);
-    let mut positional_result = cluster
-        .query(
-            "select name, type from `travel-sample` where name = ?",
-            Some(positional_options),
-        )
-        .wait()
-        .expect("Could not perform query");
+    let f = async {
+        let positional_options =
+            QueryOptions::new().set_positional_parameters(vec![json!("Texas Wings")]);
+        let mut positional_result = cluster
+            .query(
+                "select name, type from `travel-sample` where name = ?",
+                Some(positional_options),
+            )
+            .await
+            .expect("Could not perform query");
 
-    println!(
-        "Rows:\n{:?}",
-        positional_result
-            .rows_as()
-            .wait()
-            .collect::<Vec<Result<Value, CouchbaseError>>>()
-    );
+        println!(
+            "Rows:\n{:?}",
+            positional_result
+                .rows_as()
+                .collect::<Vec<Result<Value, CouchbaseError>>>().await
+        );
 
-    let mut named_params = HashMap::new();
-    named_params.insert("name".into(), json!("Texas Wings"));
-    let named_options = QueryOptions::new().set_named_parameters(named_params);
-    let mut named_result = cluster
-        .query(
-            "select name, type from `travel-sample` where name = $name",
-            Some(named_options),
-        )
-        .wait()
-        .expect("Could not perform query");
+        let mut named_params = HashMap::new();
+        named_params.insert("name".into(), json!("Texas Wings"));
+        let named_options = QueryOptions::new().set_named_parameters(named_params);
+        let mut named_result = cluster
+            .query(
+                "select name, type from `travel-sample` where name = $name",
+                Some(named_options),
+            )
+            .await
+            .expect("Could not perform query");
 
-    println!(
-        "Rows:\n{:?}",
-        named_result
-            .rows_as()
-            .wait()
-            .collect::<Vec<Result<Value, CouchbaseError>>>()
-    );
+        println!(
+            "Rows:\n{:?}",
+            named_result
+                .rows_as()
+                .collect::<Vec<Result<Value, CouchbaseError>>>().await
+        );
 
-    cluster.disconnect().expect("Could not shutdown properly");
+        cluster.disconnect().expect("Could not shutdown properly");
+    };
+    block_on(f);
 }

--- a/couchbase/examples/query_simple.rs
+++ b/couchbase/examples/query_simple.rs
@@ -1,5 +1,6 @@
 use couchbase::{Cluster, CouchbaseError};
-use futures::{Future, Stream};
+use futures::executor::block_on;
+use futures::stream::StreamExt;
 use serde_json::Value;
 
 fn main() {
@@ -9,22 +10,24 @@ fn main() {
         .expect("Could not create cluster reference");
     let _ = cluster.bucket("travel-sample");
 
-    let mut result = cluster
-        .query("select name, type from `travel-sample` limit 5", None)
-        .wait()
-        .expect("Could not perform query");
+    let f = async {
+        let mut result = cluster
+            .query("select name, type from `travel-sample` limit 5", None)
+            .await
+            .expect("Could not perform query");
 
-    println!(
-        "Rows:\n{:?}",
-        result
-            .rows_as()
-            .wait()
-            .collect::<Vec<Result<Value, CouchbaseError>>>()
-    );
-    println!(
-        "Meta:\n{:?}",
-        result.meta().wait().expect("Could not get query meta")
-    );
+        println!(
+            "Rows:\n{:?}",
+            result
+                .rows_as()
+                .collect::<Vec<Result<Value, CouchbaseError>>>().await
+        );
+        println!(
+            "Meta:\n{:?}",
+            result.meta().await.expect("Could not get query meta")
+        );
 
-    cluster.disconnect().expect("Could not shutdown properly");
+        cluster.disconnect().expect("Could not shutdown properly");
+    };
+    block_on(f);
 }

--- a/couchbase/examples/query_simple.rs
+++ b/couchbase/examples/query_simple.rs
@@ -19,7 +19,7 @@ fn main() {
         println!(
             "Rows:\n{:?}",
             result
-                .rows_as()
+                .rows_as().expect("Rows already consumed")
                 .collect::<Vec<Result<Value, CouchbaseError>>>().await
         );
         println!(

--- a/couchbase/src/bucket.rs
+++ b/couchbase/src/bucket.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 /// Provides access to `Bucket` level operations and `Collections`.
+#[derive(Debug)]
 pub struct Bucket {
     instance: Rc<Instance>,
 }
@@ -64,6 +65,7 @@ impl Bucket {
 }
 
 /// Provides access to `SharedBucket` level operations and `SharedCollections`.
+#[derive(Debug)]
 pub struct SharedBucket {
     instance: Arc<SharedInstance>,
 }
@@ -97,7 +99,7 @@ impl SharedBucket {
     where
         S: Into<String>,
     {
-        self.instance.query(statement.into(), options).await.await
+        self.instance.query(statement.into(), options).await
     }
 
     /// Internal proxy method that gets called from the cluster so we can send it into the
@@ -110,7 +112,7 @@ impl SharedBucket {
     where
         S: Into<String>,
     {
-        self.instance.analytics_query(statement.into(), options).await.await
+        self.instance.analytics_query(statement.into(), options).await
     }
 
     /// Internal proxy method that gets called from the cluster so we can send it into the

--- a/couchbase/src/bucket.rs
+++ b/couchbase/src/bucket.rs
@@ -3,7 +3,6 @@ use crate::error::CouchbaseError;
 use crate::instance::{Instance, SharedInstance};
 use crate::options::{AnalyticsOptions, QueryOptions};
 use crate::result::{AnalyticsResult, QueryResult};
-use futures::Future;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -33,28 +32,28 @@ impl Bucket {
 
     /// Internal proxy method that gets called from the cluster so we can send it into the
     /// instance.
-    pub(crate) fn query<S>(
+    pub(crate) async fn query<S>(
         &self,
         statement: S,
         options: Option<QueryOptions>,
-    ) -> impl Future<Item = QueryResult, Error = CouchbaseError>
+    ) -> Result<QueryResult, CouchbaseError>
     where
         S: Into<String>,
     {
-        self.instance.query(statement.into(), options)
+        self.instance.query(statement.into(), options).await
     }
 
     /// Internal proxy method that gets called from the cluster so we can send it into the
     /// instance.
-    pub(crate) fn analytics_query<S>(
+    pub(crate) async fn analytics_query<S>(
         &self,
         statement: S,
         options: Option<AnalyticsOptions>,
-    ) -> impl Future<Item = AnalyticsResult, Error = CouchbaseError>
+    ) -> Result<AnalyticsResult, CouchbaseError>
     where
         S: Into<String>,
     {
-        self.instance.analytics_query(statement.into(), options)
+        self.instance.analytics_query(statement.into(), options).await
     }
 
     /// Internal proxy method that gets called from the cluster so we can send it into the
@@ -90,33 +89,33 @@ impl SharedBucket {
 
     /// Internal proxy method that gets called from the cluster so we can send it into the
     /// instance.
-    pub(crate) fn query<S>(
+    pub(crate) async fn query<S>(
         &self,
         statement: S,
         options: Option<QueryOptions>,
-    ) -> impl Future<Item = QueryResult, Error = CouchbaseError>
+    ) -> Result<QueryResult, CouchbaseError>
     where
         S: Into<String>,
     {
-        self.instance.query(statement.into(), options)
+        self.instance.query(statement.into(), options).await.await
     }
 
     /// Internal proxy method that gets called from the cluster so we can send it into the
     /// instance.
-    pub(crate) fn analytics_query<S>(
+    pub(crate) async fn analytics_query<S>(
         &self,
         statement: S,
         options: Option<AnalyticsOptions>,
-    ) -> impl Future<Item = AnalyticsResult, Error = CouchbaseError>
+    ) -> Result<AnalyticsResult, CouchbaseError>
     where
         S: Into<String>,
     {
-        self.instance.analytics_query(statement.into(), options)
+        self.instance.analytics_query(statement.into(), options).await.await
     }
 
     /// Internal proxy method that gets called from the cluster so we can send it into the
     /// instance.
-    pub(crate) fn close(&self) -> Result<(), CouchbaseError> {
-        self.instance.shutdown()
+    pub(crate) async fn close(&self) -> Result<(), CouchbaseError> {
+        self.instance.shutdown().await
     }
 }

--- a/couchbase/src/cluster.rs
+++ b/couchbase/src/cluster.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 /// The `Cluster` is the main entry point when working with the client.
+#[derive(Debug)]
 pub struct Cluster {
     connection_string: String,
     username: String,
@@ -121,7 +122,7 @@ impl Cluster {
     ///     .await
     ///     .expect("Could not perform query");
     ///
-    /// println!("Rows:\n{:?}", result.rows_as().collect::<Vec<Result<Value, CouchbaseError>>>().await);
+    /// println!("Rows:\n{:?}", result.rows_as().expect("already consumed").collect::<Vec<Result<Value, CouchbaseError>>>().await);
     /// println!("Meta:\n{:?}", result.meta().await.expect("Could not get query meta"));
     /// # };
     /// ```
@@ -170,7 +171,7 @@ impl Cluster {
     ///     .await
     ///     .expect("Could not perform analytics query");
     ///
-    /// println!("---> rows {:?}", result.rows_as().collect::<Vec<Result<Value, CouchbaseError>>>().await);
+    /// println!("---> rows {:?}", result.rows_as().expect("Rows consumed").collect::<Vec<Result<Value, CouchbaseError>>>().await);
     /// println!("---> meta {:?}", result.meta().await.expect("Could not get analytics meta"));
     /// # };
     /// ```
@@ -216,6 +217,7 @@ impl Cluster {
 }
 
 /// The `Cluster` is the main entry point when working with the client.
+#[derive(Debug)]
 pub struct SharedCluster {
     connection_string: String,
     username: String,
@@ -329,7 +331,7 @@ impl SharedCluster {
     ///     .await
     ///     .expect("Could not perform query");
     ///
-    /// println!("Rows:\n{:?}", result.rows_as().collect::<Vec<Result<Value, CouchbaseError>>>().await);
+    /// println!("Rows:\n{:?}", result.rows_as().expect("Rows already consumed").collect::<Vec<Result<Value, CouchbaseError>>>().await);
     /// println!("Meta:\n{:?}", result.meta().await.expect("Could not get query meta"));
     /// # };
     /// ```
@@ -378,7 +380,7 @@ impl SharedCluster {
     ///     .await
     ///     .expect("Could not perform analytics query");
     ///
-    /// println!("---> rows {:?}", result.rows_as().collect::<Vec<Result<Value, CouchbaseError>>>().await);
+    /// println!("---> rows {:?}", result.rows_as().expect("Rows consumed").collect::<Vec<Result<Value, CouchbaseError>>>().await);
     /// println!("---> meta {:?}", result.meta().await.expect("Could not get analytics meta"));
     /// # };
     /// ```

--- a/couchbase/src/cluster.rs
+++ b/couchbase/src/cluster.rs
@@ -3,7 +3,6 @@ use crate::bucket::{Bucket, SharedBucket};
 use crate::error::CouchbaseError;
 use crate::options::{AnalyticsOptions, QueryOptions};
 use crate::result::{AnalyticsResult, QueryResult};
-use futures::Future;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -111,25 +110,27 @@ impl Cluster {
     ///
     /// ```rust,no_run
     /// use couchbase::{CouchbaseError, Cluster};
-    /// use futures::{Stream, Future};
+    /// use futures::{Stream, StreamExt, Future};
     /// use serde_json::Value;
     /// # let mut cluster = Cluster::connect("couchbase://127.0.0.1", "Administrator", "password")
     /// #    .expect("Could not create cluster reference");
     /// # let _ = cluster.bucket("travel-sample");
     /// #
+    /// # async {
     /// let mut result = cluster.query("select name, type from `travel-sample` limit 5", None)
-    ///     .wait()
+    ///     .await
     ///     .expect("Could not perform query");
     ///
-    /// println!("Rows:\n{:?}", result.rows_as().wait().collect::<Vec<Result<Value, CouchbaseError>>>());
-    /// println!("Meta:\n{:?}", result.meta().wait().expect("Could not get query meta"));
+    /// println!("Rows:\n{:?}", result.rows_as().collect::<Vec<Result<Value, CouchbaseError>>>().await);
+    /// println!("Meta:\n{:?}", result.meta().await.expect("Could not get query meta"));
+    /// # };
     /// ```
     ///
-    pub fn query<S>(
+    pub async fn query<S>(
         &self,
         statement: S,
         options: Option<QueryOptions>,
-    ) -> impl Future<Item = QueryResult, Error = CouchbaseError>
+    ) -> Result<QueryResult, CouchbaseError>
     where
         S: Into<String>,
     {
@@ -138,7 +139,7 @@ impl Cluster {
             None => panic!("At least one bucket needs to be open to perform a query for now!"),
         };
 
-        bucket.query(statement, options)
+        bucket.query(statement, options).await
     }
 
     /// Performs a query against the analytics service.
@@ -156,27 +157,29 @@ impl Cluster {
     ///
     /// ```rust,no_run
     /// use couchbase::{CouchbaseError, Cluster};
-    /// use futures::{Stream, Future};
+    /// use futures::{Stream, StreamExt, Future};
     /// use serde_json::Value;
     /// #
     /// # let mut cluster = Cluster::connect("couchbase://127.0.0.1", "Administrator", "password")
     /// #     .expect("Could not create cluster reference!");
     /// # let _ = cluster.bucket("travel-sample");
     /// #
+    /// # async {
     /// let mut result = cluster
     ///     .analytics_query("SELECT DataverseName FROM Metadata.`Dataverse`", None)
-    ///     .wait()
+    ///     .await
     ///     .expect("Could not perform analytics query");
     ///
-    /// println!("---> rows {:?}", result.rows_as().wait().collect::<Vec<Result<Value, CouchbaseError>>>());
-    /// println!("---> meta {:?}", result.meta().wait().expect("Could not get analytics meta"));
+    /// println!("---> rows {:?}", result.rows_as().collect::<Vec<Result<Value, CouchbaseError>>>().await);
+    /// println!("---> meta {:?}", result.meta().await.expect("Could not get analytics meta"));
+    /// # };
     /// ```
     ///
-    pub fn analytics_query<S>(
+    pub async fn analytics_query<S>(
         &self,
         statement: S,
         options: Option<AnalyticsOptions>,
-    ) -> impl Future<Item = AnalyticsResult, Error = CouchbaseError>
+    ) -> Result<AnalyticsResult, CouchbaseError>
     where
         S: Into<String>,
     {
@@ -187,7 +190,7 @@ impl Cluster {
             ),
         };
 
-        bucket.analytics_query(statement, options)
+        bucket.analytics_query(statement, options).await
     }
 
     /// Disconnects this cluster and all associated open buckets.
@@ -315,25 +318,27 @@ impl SharedCluster {
     ///
     /// ```rust,no_run
     /// use couchbase::{CouchbaseError, SharedCluster};
-    /// use futures::{Stream, Future};
+    /// use futures::{Stream, StreamExt, Future};
     /// use serde_json::Value;
     /// # let mut cluster = SharedCluster::connect("couchbase://127.0.0.1", "Administrator", "password")
     /// #    .expect("Could not create cluster reference");
     /// # let _ = cluster.bucket("travel-sample");
     /// #
+    /// # async {
     /// let mut result = cluster.query("select name, type from `travel-sample` limit 5", None)
-    ///     .wait()
+    ///     .await
     ///     .expect("Could not perform query");
     ///
-    /// println!("Rows:\n{:?}", result.rows_as().wait().collect::<Vec<Result<Value, CouchbaseError>>>());
-    /// println!("Meta:\n{:?}", result.meta().wait().expect("Could not get query meta"));
+    /// println!("Rows:\n{:?}", result.rows_as().collect::<Vec<Result<Value, CouchbaseError>>>().await);
+    /// println!("Meta:\n{:?}", result.meta().await.expect("Could not get query meta"));
+    /// # };
     /// ```
     ///
-    pub fn query<S>(
+    pub async fn query<S>(
         &self,
         statement: S,
         options: Option<QueryOptions>,
-    ) -> impl Future<Item = QueryResult, Error = CouchbaseError>
+    ) -> Result<QueryResult, CouchbaseError>
     where
         S: Into<String>,
     {
@@ -342,7 +347,7 @@ impl SharedCluster {
             None => panic!("At least one bucket needs to be open to perform a query for now!"),
         };
 
-        bucket.query(statement, options)
+        bucket.query(statement, options).await
     }
 
     /// Performs a query against the analytics service.
@@ -360,27 +365,29 @@ impl SharedCluster {
     ///
     /// ```rust,no_run
     /// use couchbase::{CouchbaseError, SharedCluster};
-    /// use futures::{Stream, Future};
+    /// use futures::{Stream, StreamExt, Future};
     /// use serde_json::Value;
     /// #
     /// # let mut cluster = SharedCluster::connect("couchbase://127.0.0.1", "Administrator", "password")
     /// #     .expect("Could not create cluster reference!");
     /// # let _ = cluster.bucket("travel-sample");
-    /// #
+    /// # 
+    /// # async {
     /// let mut result = cluster
     ///     .analytics_query("SELECT DataverseName FROM Metadata.`Dataverse`", None)
-    ///     .wait()
+    ///     .await
     ///     .expect("Could not perform analytics query");
     ///
-    /// println!("---> rows {:?}", result.rows_as().wait().collect::<Vec<Result<Value, CouchbaseError>>>());
-    /// println!("---> meta {:?}", result.meta().wait().expect("Could not get analytics meta"));
+    /// println!("---> rows {:?}", result.rows_as().collect::<Vec<Result<Value, CouchbaseError>>>().await);
+    /// println!("---> meta {:?}", result.meta().await.expect("Could not get analytics meta"));
+    /// # };
     /// ```
     ///
-    pub fn analytics_query<S>(
+    pub async fn analytics_query<S>(
         &self,
         statement: S,
         options: Option<AnalyticsOptions>,
-    ) -> impl Future<Item = AnalyticsResult, Error = CouchbaseError>
+    ) -> Result<AnalyticsResult, CouchbaseError>
     where
         S: Into<String>,
     {
@@ -391,7 +398,7 @@ impl SharedCluster {
             ),
         };
 
-        bucket.analytics_query(statement, options)
+        bucket.analytics_query(statement, options).await
     }
 
     /// Disconnects this cluster and all associated open buckets.
@@ -404,12 +411,14 @@ impl SharedCluster {
     /// # let mut cluster = SharedCluster::connect("couchbase://127.0.0.1", "Administrator", "password")
     /// #    .expect("Could not create cluster reference!");
     /// #
-    /// cluster.disconnect().expect("Could not shutdown properly");
+    /// # async {
+    /// cluster.disconnect().await.expect("Could not shutdown properly");
+    /// # };
     /// ```
     ///
-    pub fn disconnect(&mut self) -> Result<(), CouchbaseError> {
+    pub async fn disconnect(&mut self) -> Result<(), CouchbaseError> {
         for bucket in self.buckets.values() {
-            bucket.close()?;
+            bucket.close().await?;
         }
         self.buckets.clear();
         Ok(())

--- a/couchbase/src/collection.rs
+++ b/couchbase/src/collection.rs
@@ -611,7 +611,7 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.get(id.into(), options).await.await
+        self.instance.get(id.into(), options).await
     }
 
     /// Fetches a document from the collection and write locks it.
@@ -657,7 +657,7 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.get_and_lock(id.into(), options).await.await
+        self.instance.get_and_lock(id.into(), options).await
     }
 
     /// Fetches a document from the collection and modifies its expiry.
@@ -703,7 +703,7 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.get_and_touch(id.into(), expiration, options).await.await
+        self.instance.get_and_touch(id.into(), expiration, options).await
     }
 
     /// Inserts or replaces a new document into the collection.
@@ -762,7 +762,7 @@ impl SharedCollection {
             Err(_e) => return Err(CouchbaseError::EncodingError),
         };
         let flags = JSON_COMMON_FLAG;
-        self.instance.upsert(id.into(), serialized, flags, options).await.await
+        self.instance.upsert(id.into(), serialized, flags, options).await
     }
 
     /// Inserts a document into the collection.
@@ -820,7 +820,7 @@ impl SharedCollection {
             Err(_e) => return Err(CouchbaseError::EncodingError),
         };
         let flags = JSON_COMMON_FLAG;
-        self.instance.insert(id.into(), serialized, flags, options).await.await
+        self.instance.insert(id.into(), serialized, flags, options).await
     }
 
     /// Replaces an existing document in the collection.
@@ -879,7 +879,7 @@ impl SharedCollection {
             Err(_e) => return Err(CouchbaseError::EncodingError),
         };
         let flags = JSON_COMMON_FLAG;
-        self.instance.replace(id.into(), serialized, flags, options).await.await
+        self.instance.replace(id.into(), serialized, flags, options).await
     }
 
     /// Removes a document from the collection.
@@ -912,7 +912,7 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.remove(id.into(), options).await.await
+        self.instance.remove(id.into(), options).await
     }
 
     /// Changes the expiration time on a document.
@@ -948,7 +948,7 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.touch(id.into(), expiration, options).await.await
+        self.instance.touch(id.into(), expiration, options).await
     }
 
     /// Unlocks a write-locked document.
@@ -984,7 +984,7 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.unlock(id.into(), cas, options).await.await
+        self.instance.unlock(id.into(), cas, options).await
     }
 
     /// Checks if a document exists and if so returns a cas value with it.
@@ -1017,7 +1017,7 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.exists(id.into(), options).await.await
+        self.instance.exists(id.into(), options).await
     }
 
     /// Extracts fragments of a document.
@@ -1055,7 +1055,7 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.lookup_in(id.into(), specs, options).await.await
+        self.instance.lookup_in(id.into(), specs, options).await
     }
 
     /// Changes fragments of a document.
@@ -1097,6 +1097,6 @@ impl SharedCollection {
     where
         S: Into<String>,
     {
-        self.instance.mutate_in(id.into(), specs, options).await.await
+        self.instance.mutate_in(id.into(), specs, options).await
     }
 }

--- a/couchbase/src/error.rs
+++ b/couchbase/src/error.rs
@@ -561,7 +561,7 @@ impl error::Error for CouchbaseError {
         self.as_str()
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }

--- a/couchbase/src/error.rs
+++ b/couchbase/src/error.rs
@@ -1,7 +1,12 @@
 //! Error handling structures and functionality.
 
+use crate::instance;
+
 use couchbase_sys::*;
 use std::{convert, error, fmt, io};
+
+use futures;
+use serde_json;
 
 /// Defines all possible errors that can result as part of interacting with the SDK.
 ///
@@ -18,10 +23,12 @@ use std::{convert, error, fmt, io};
 pub enum CouchbaseError {
     /// Call succeded.
     Success,
+    IoError(std::io::Error),
     /// Raised when there has been a problem with dispatching the rust future.
-    FutureError,
+    FutureError(String),
     /// Decoding from json or another type failed.
-    DecodingError,
+    DecodingError(serde_json::Error),
+    InternalChannelSendError(String),
     /// Encoding into json failed.
     EncodingError,
     /// This error is received when connecting or reconnecting to the cluster.
@@ -332,16 +339,24 @@ pub enum CouchbaseError {
     DurabilitySyncWriteAmbiguous,
     /// If the rust binding doesn't know about an error its contained here.
     UnknownLibcouchbaseError(u32),
+    RowsConsumed,
+    MetaConsumed,
+    FutureCanceled(futures::channel::oneshot::Canceled),
 }
 
 impl CouchbaseError {
     fn as_str(&self) -> &'static str {
         match *self {
-            CouchbaseError::Success => { "Success" }
-            CouchbaseError::FutureError => {
+            CouchbaseError::RowsConsumed => { "Rows already consumed in result" },
+            CouchbaseError::MetaConsumed => { "Meta already consumed in result" },
+            CouchbaseError::FutureCanceled(_) => { "Future is canceled" },
+            CouchbaseError::IoError(_) => { "IO Error" },
+            CouchbaseError::Success => { "Success" },
+            CouchbaseError::InternalChannelSendError(_) => { "Error sending to internal instance channel" },
+            CouchbaseError::FutureError(_) => {
                 "Could not dispatch the rust future"
             },
-            CouchbaseError::DecodingError => "Decoding failed",
+            CouchbaseError::DecodingError(_) => "Decoding failed",
             CouchbaseError::EncodingError => "Encoding failed",
             CouchbaseError::AuthFailed => {
                 "Authentication failed. You may have provided an invalid username/password \
@@ -568,7 +583,43 @@ impl error::Error for CouchbaseError {
 
 impl fmt::Display for CouchbaseError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.as_str())
+        let msg = match &*self {
+            CouchbaseError::FutureError(e) => format!("Future Error: {}", e),
+            CouchbaseError::DecodingError(e) => format!("Decoding Error: {}", e),
+            CouchbaseError::FutureCanceled(e) => format!("Future Canceled Error: {}", e),
+            CouchbaseError::IoError(e) => format!("IO Error: {}", e),
+            CouchbaseError::InternalChannelSendError(e) => format!("Channel Send Error: {}", e),
+            err => format!("{}", err.as_str()),
+        };
+        write!(fmt, "{}", msg)
+    }
+}
+
+impl convert::From<std::sync::mpsc::SendError<Box<dyn instance::request::InstanceRequest>>>
+    for CouchbaseError
+{
+    fn from(
+        err: std::sync::mpsc::SendError<Box<dyn instance::request::InstanceRequest>>,
+    ) -> CouchbaseError {
+        CouchbaseError::InternalChannelSendError(format!("{}", err))
+    }
+}
+
+impl convert::From<std::io::Error> for CouchbaseError {
+    fn from(err: std::io::Error) -> CouchbaseError {
+        CouchbaseError::IoError(err)
+    }
+}
+
+impl convert::From<serde_json::Error> for CouchbaseError {
+    fn from(err: serde_json::Error) -> CouchbaseError {
+        CouchbaseError::DecodingError(err)
+    }
+}
+
+impl convert::From<futures::channel::oneshot::Canceled> for CouchbaseError {
+    fn from(err: futures::channel::oneshot::Canceled) -> CouchbaseError {
+        CouchbaseError::FutureCanceled(err)
     }
 }
 

--- a/couchbase/src/instance/mod.rs
+++ b/couchbase/src/instance/mod.rs
@@ -11,8 +11,10 @@ use crate::options::*;
 use crate::result::*;
 use crate::subdoc::*;
 use couchbase_sys::*;
-use futures::sync::oneshot;
+use futures::channel::oneshot;
+use futures::lock::Mutex;
 use futures::Future;
+use futures::FutureExt;
 use request::*;
 use std::cell::RefCell;
 use std::ffi::c_void;
@@ -21,7 +23,6 @@ use std::os::raw::{c_char, c_int, c_uint};
 use std::ptr;
 use std::slice::from_raw_parts;
 use std::sync::mpsc::{channel, Sender};
-use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
@@ -72,7 +73,7 @@ impl InstanceCookie {
 ///
 /// An `Instance` is always bound to a bucket, since this is how lcb works.
 pub struct Instance {
-    sender: Sender<Box<InstanceRequest>>,
+    sender: Sender<Box<dyn InstanceRequest>>,
     handle: RefCell<Option<thread::JoinHandle<()>>>,
 }
 
@@ -92,7 +93,7 @@ impl Instance {
             Err(_) => return Err(CouchbaseError::InvalidValue),
         };
 
-        let (tx, rx) = channel::<Box<InstanceRequest>>();
+        let (tx, rx) = channel::<Box<dyn InstanceRequest>>();
 
         let handle = thread::Builder::new()
             .spawn(move || {
@@ -184,200 +185,200 @@ impl Instance {
         }
     }
 
-    pub fn get(
+    pub async fn get(
         &self,
         id: String,
         options: Option<GetOptions>,
-    ) -> impl Future<Item = GetResult, Error = CouchbaseError> {
+    ) -> Result<GetResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(GetRequest::new(p, id, options)))
             .expect("Could not send get command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn get_and_lock(
+    pub async fn get_and_lock(
         &self,
         id: String,
         options: Option<GetAndLockOptions>,
-    ) -> impl Future<Item = GetResult, Error = CouchbaseError> {
+    ) -> Result<GetResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(GetAndLockRequest::new(p, id, options)))
             .expect("Could not send getAndLock command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn get_and_touch(
+    pub async fn get_and_touch(
         &self,
         id: String,
         expiration: Duration,
         options: Option<GetAndTouchOptions>,
-    ) -> impl Future<Item = GetResult, Error = CouchbaseError> {
+    ) -> Result<GetResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(GetAndTouchRequest::new(
                 p, id, expiration, options,
             )))
             .expect("Could not send getAndTouch command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn exists(
+    pub async fn exists(
         &self,
         id: String,
         options: Option<ExistsOptions>,
-    ) -> impl Future<Item = ExistsResult, Error = CouchbaseError> {
+    ) -> Result<ExistsResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(ExistsRequest::new(p, id, options)))
             .expect("Could not send exists command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn upsert(
+    pub async fn upsert(
         &self,
         id: String,
         content: Vec<u8>,
         flags: u32,
         options: Option<UpsertOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> Result<MutationResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(UpsertRequest::new(p, id, content, flags, options)))
             .expect("Could not send upsert command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn insert(
+    pub async fn insert(
         &self,
         id: String,
         content: Vec<u8>,
         flags: u32,
         options: Option<InsertOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> Result<MutationResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(InsertRequest::new(p, id, content, flags, options)))
             .expect("Could not send insert command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn replace(
+    pub async fn replace(
         &self,
         id: String,
         content: Vec<u8>,
         flags: u32,
         options: Option<ReplaceOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> Result<MutationResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(ReplaceRequest::new(
                 p, id, content, flags, options,
             )))
             .expect("Could not send replace command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn remove(
+    pub async fn remove(
         &self,
         id: String,
         options: Option<RemoveOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> Result<MutationResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(RemoveRequest::new(p, id, options)))
             .expect("Could not send remove command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn touch(
+    pub async fn touch(
         &self,
         id: String,
         expiration: Duration,
         options: Option<TouchOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> Result<MutationResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(TouchRequest::new(p, id, expiration, options)))
             .expect("Could not send touch command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn unlock(
+    pub async fn unlock(
         &self,
         id: String,
         cas: u64,
         options: Option<UnlockOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> Result<MutationResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(UnlockRequest::new(p, id, cas, options)))
             .expect("Could not send unlock command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn lookup_in(
+    pub async fn lookup_in(
         &self,
         id: String,
         specs: Vec<LookupInSpec>,
         options: Option<LookupInOptions>,
-    ) -> impl Future<Item = LookupInResult, Error = CouchbaseError> {
+    ) -> Result<LookupInResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(LookupInRequest::new(p, id, specs, options)))
             .expect("Could not send lookupIn command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn mutate_in(
+    pub async fn mutate_in(
         &self,
         id: String,
         specs: Vec<MutateInSpec>,
         options: Option<MutateInOptions>,
-    ) -> impl Future<Item = MutateInResult, Error = CouchbaseError> {
+    ) -> Result<MutateInResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(MutateInRequest::new(p, id, specs, options)))
             .expect("Could not send mutateIn command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn query(
+    pub async fn query(
         &self,
         statement: String,
         options: Option<QueryOptions>,
-    ) -> impl Future<Item = QueryResult, Error = CouchbaseError> {
+    ) -> Result<QueryResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(QueryRequest::new(p, statement, options)))
             .expect("Could not send query command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 
-    pub fn analytics_query(
+    pub async fn analytics_query(
         &self,
         statement: String,
         options: Option<AnalyticsOptions>,
-    ) -> impl Future<Item = AnalyticsResult, Error = CouchbaseError> {
+    ) -> Result<AnalyticsResult, CouchbaseError> {
         let (p, c) = oneshot::channel();
         self.sender
             .send(Box::new(AnalyticsRequest::new(p, statement, options)))
             .expect("Could not send analytics query command into io loop");
-        map_oneshot_error(c)
+        map_oneshot_error(c).await
     }
 }
 
-fn map_oneshot_error<T>(
+async fn map_oneshot_error<T>(
     receiver: oneshot::Receiver<Result<T, CouchbaseError>>,
-) -> impl Future<Item = T, Error = CouchbaseError> {
-    receiver.then(|value| match value {
+) -> Result<T, CouchbaseError> {
+    receiver.map(|value| match value {
         Ok(v) => match v {
             Ok(i) => Ok(i),
             Err(e) => Err(e),
         },
         Err(_) => Err(CouchbaseError::FutureError),
-    })
+    }).await
 }
 
 /// The `Instance` provides safe APIs around the inherently unsafe access
@@ -389,7 +390,7 @@ fn map_oneshot_error<T>(
 ///
 /// An `Instance` is always bound to a bucket, since this is how lcb works.
 pub struct SharedInstance {
-    sender: Mutex<Sender<Box<InstanceRequest>>>,
+    sender: Mutex<Sender<Box<dyn InstanceRequest>>>,
     handle: Mutex<Option<thread::JoinHandle<()>>>,
 }
 
@@ -409,7 +410,7 @@ impl SharedInstance {
             Err(_) => return Err(CouchbaseError::InvalidValue),
         };
 
-        let (tx, rx) = channel::<Box<InstanceRequest>>();
+        let (tx, rx) = channel::<Box<dyn InstanceRequest>>();
 
         let handle = thread::Builder::new()
             .spawn(move || {
@@ -486,13 +487,13 @@ impl SharedInstance {
         })
     }
 
-    pub fn shutdown(&self) -> Result<(), CouchbaseError> {
-        match self.handle.lock().unwrap().take() {
+    pub async fn shutdown(&self) -> Result<(), CouchbaseError> {
+        match self.handle.lock().await.take() {
             Some(h) => {
                 match self
                     .sender
                     .lock()
-                    .unwrap()
+                    .await
                     .send(Box::new(ShutdownRequest::new()))
                 {
                     Ok(_) => (),
@@ -506,44 +507,44 @@ impl SharedInstance {
         }
     }
 
-    pub fn get(
+    pub async fn get(
         &self,
         id: String,
         options: Option<GetOptions>,
-    ) -> impl Future<Item = GetResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<GetResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(GetRequest::new(p, id, options)))
             .expect("Could not send get command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn get_and_lock(
+    pub async fn get_and_lock(
         &self,
         id: String,
         options: Option<GetAndLockOptions>,
-    ) -> impl Future<Item = GetResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<GetResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(GetAndLockRequest::new(p, id, options)))
             .expect("Could not send getAndLock command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn get_and_touch(
+    pub async fn get_and_touch(
         &self,
         id: String,
         expiration: Duration,
         options: Option<GetAndTouchOptions>,
-    ) -> impl Future<Item = GetResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<GetResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(GetAndTouchRequest::new(
                 p, id, expiration, options,
             )))
@@ -551,63 +552,63 @@ impl SharedInstance {
         map_oneshot_error(c)
     }
 
-    pub fn exists(
+    pub async fn exists(
         &self,
         id: String,
         options: Option<ExistsOptions>,
-    ) -> impl Future<Item = ExistsResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<ExistsResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(ExistsRequest::new(p, id, options)))
             .expect("Could not send exists command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn upsert(
+    pub async fn upsert(
         &self,
         id: String,
         content: Vec<u8>,
         flags: u32,
         options: Option<UpsertOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<MutationResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(UpsertRequest::new(p, id, content, flags, options)))
             .expect("Could not send upsert command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn insert(
+    pub async fn insert(
         &self,
         id: String,
         content: Vec<u8>,
         flags: u32,
         options: Option<InsertOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<MutationResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(InsertRequest::new(p, id, content, flags, options)))
             .expect("Could not send insert command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn replace(
+    pub async fn replace(
         &self,
         id: String,
         content: Vec<u8>,
         flags: u32,
         options: Option<ReplaceOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<MutationResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(ReplaceRequest::new(
                 p, id, content, flags, options,
             )))
@@ -615,103 +616,103 @@ impl SharedInstance {
         map_oneshot_error(c)
     }
 
-    pub fn remove(
+    pub async fn remove(
         &self,
         id: String,
         options: Option<RemoveOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<MutationResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(RemoveRequest::new(p, id, options)))
             .expect("Could not send remove command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn touch(
+    pub async fn touch(
         &self,
         id: String,
         expiration: Duration,
         options: Option<TouchOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<MutationResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(TouchRequest::new(p, id, expiration, options)))
             .expect("Could not send touch command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn unlock(
+    pub async fn unlock(
         &self,
         id: String,
         cas: u64,
         options: Option<UnlockOptions>,
-    ) -> impl Future<Item = MutationResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<MutationResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(UnlockRequest::new(p, id, cas, options)))
             .expect("Could not send unlock command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn lookup_in(
+    pub async fn lookup_in(
         &self,
         id: String,
         specs: Vec<LookupInSpec>,
         options: Option<LookupInOptions>,
-    ) -> impl Future<Item = LookupInResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<LookupInResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(LookupInRequest::new(p, id, specs, options)))
             .expect("Could not send lookupIn command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn mutate_in(
+    pub async fn mutate_in(
         &self,
         id: String,
         specs: Vec<MutateInSpec>,
         options: Option<MutateInOptions>,
-    ) -> impl Future<Item = MutateInResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<MutateInResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(MutateInRequest::new(p, id, specs, options)))
             .expect("Could not send mutateIn command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn query(
+    pub async fn query(
         &self,
         statement: String,
         options: Option<QueryOptions>,
-    ) -> impl Future<Item = QueryResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<QueryResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(QueryRequest::new(p, statement, options)))
             .expect("Could not send query command into io loop");
         map_oneshot_error(c)
     }
 
-    pub fn analytics_query(
+    pub async fn analytics_query(
         &self,
         statement: String,
         options: Option<AnalyticsOptions>,
-    ) -> impl Future<Item = AnalyticsResult, Error = CouchbaseError> {
+    ) -> impl Future<Output = Result<AnalyticsResult, CouchbaseError>> {
         let (p, c) = oneshot::channel();
         self.sender
             .lock()
-            .unwrap()
+            .await
             .send(Box::new(AnalyticsRequest::new(p, statement, options)))
             .expect("Could not send analytics query command into io loop");
         map_oneshot_error(c)
@@ -784,9 +785,8 @@ unsafe extern "C" fn get_callback(
 
     let mut cookie_ptr: *mut c_void = ptr::null_mut();
     lcb_respget_cookie(get_res, &mut cookie_ptr);
-    let sender = Box::from_raw(
-        cookie_ptr as *mut oneshot::Sender<Result<GetResult, CouchbaseError>>,
-    );
+    let sender =
+        Box::from_raw(cookie_ptr as *mut oneshot::Sender<Result<GetResult, CouchbaseError>>);
 
     let status = lcb_respget_status(get_res);
     let result = if status == lcb_STATUS_LCB_SUCCESS {
@@ -915,9 +915,8 @@ unsafe extern "C" fn exists_callback(
 
     let mut cookie_ptr: *mut c_void = ptr::null_mut();
     lcb_respexists_cookie(exists_res, &mut cookie_ptr);
-    let sender = Box::from_raw(
-        cookie_ptr as *mut oneshot::Sender<Result<ExistsResult, CouchbaseError>>,
-    );
+    let sender =
+        Box::from_raw(cookie_ptr as *mut oneshot::Sender<Result<ExistsResult, CouchbaseError>>);
 
     let mut cas: u64 = 0;
     lcb_respexists_cas(exists_res, &mut cas);
@@ -941,9 +940,8 @@ unsafe extern "C" fn lookup_in_callback(
 
     let mut cookie_ptr: *mut c_void = ptr::null_mut();
     lcb_respsubdoc_cookie(lookup_res, &mut cookie_ptr);
-    let sender = Box::from_raw(
-        cookie_ptr as *mut oneshot::Sender<Result<LookupInResult, CouchbaseError>>,
-    );
+    let sender =
+        Box::from_raw(cookie_ptr as *mut oneshot::Sender<Result<LookupInResult, CouchbaseError>>);
 
     let status = lcb_respsubdoc_status(lookup_res);
     let result = if status == lcb_STATUS_LCB_SUCCESS {

--- a/couchbase/src/instance/mod.rs
+++ b/couchbase/src/instance/mod.rs
@@ -13,7 +13,6 @@ use crate::subdoc::*;
 use couchbase_sys::*;
 use futures::channel::oneshot;
 use futures::lock::Mutex;
-use futures::Future;
 use futures::FutureExt;
 use request::*;
 use std::cell::RefCell;

--- a/couchbase/src/instance/request.rs
+++ b/couchbase/src/instance/request.rs
@@ -5,7 +5,7 @@ use crate::options::*;
 use crate::result::*;
 use crate::subdoc::*;
 use couchbase_sys::*;
-use futures::sync::{mpsc, oneshot};
+use futures::channel::{mpsc, oneshot};
 use std::ffi::{c_void, CString};
 use std::os::raw::c_char;
 use std::ptr;
@@ -564,7 +564,7 @@ impl QueryRequest {
         let len = uuid.len();
         let client_context_id = CString::new(uuid).unwrap();
         println!("writing internal ccid");
-        lcb_cmdn1ql_client_context_id(command, client_context_id.as_ptr(), len);   
+        lcb_cmdn1ql_client_context_id(command, client_context_id.as_ptr(), len);
     }
 }
 
@@ -610,7 +610,11 @@ impl InstanceRequest for QueryRequest {
 
                 if let Some(client_context_id) = options.client_context_id() {
                     println!("Writing custom ccid");
-                    lcb_cmdn1ql_client_context_id(command, client_context_id.0.as_ptr(), client_context_id.1);
+                    lcb_cmdn1ql_client_context_id(
+                        command,
+                        client_context_id.0.as_ptr(),
+                        client_context_id.1,
+                    );
                 } else {
                     QueryRequest::add_default_client_context_id(command);
                 }

--- a/couchbase/src/instance/request.rs
+++ b/couchbase/src/instance/request.rs
@@ -563,7 +563,6 @@ impl QueryRequest {
         let uuid = format!("{}", Uuid::new_v4());
         let len = uuid.len();
         let client_context_id = CString::new(uuid).unwrap();
-        println!("writing internal ccid");
         lcb_cmdn1ql_client_context_id(command, client_context_id.as_ptr(), len);
     }
 }
@@ -609,7 +608,6 @@ impl InstanceRequest for QueryRequest {
                 }
 
                 if let Some(client_context_id) = options.client_context_id() {
-                    println!("Writing custom ccid");
                     lcb_cmdn1ql_client_context_id(
                         command,
                         client_context_id.0.as_ptr(),

--- a/couchbase/src/result.rs
+++ b/couchbase/src/result.rs
@@ -5,10 +5,9 @@ use std::str;
 
 use crate::error::CouchbaseError;
 use futures::channel::{mpsc, oneshot};
-use futures::stream::{self, StreamExt};
+use futures::stream::StreamExt;
 use futures::Stream;
-use futures::TryFutureExt;
-use futures::{self, Future};
+use futures;
 use serde::de::DeserializeOwned;
 use serde_derive::Deserialize;
 use serde_json::{from_slice, Value};

--- a/couchbase/src/result.rs
+++ b/couchbase/src/result.rs
@@ -5,10 +5,10 @@ use std::str;
 
 use crate::error::CouchbaseError;
 use futures::channel::{mpsc, oneshot};
-use futures::stream::StreamExt;
-use futures::Future;
+use futures::stream::{self, StreamExt};
 use futures::Stream;
 use futures::TryFutureExt;
+use futures::{self, Future};
 use serde::de::DeserializeOwned;
 use serde_derive::Deserialize;
 use serde_json::{from_slice, Value};
@@ -38,7 +38,7 @@ impl GetResult {
     {
         match from_slice(&self.encoded.as_slice()) {
             Ok(v) => Ok(v),
-            Err(_e) => Err(CouchbaseError::DecodingError),
+            Err(e) => Err(CouchbaseError::DecodingError(e)),
         }
     }
 }
@@ -132,25 +132,33 @@ impl QueryResult {
         }
     }
 
-    pub fn rows_as<T>(&mut self) -> impl Stream<Item = Result<T, CouchbaseError>>
+    pub fn rows_as<T>(
+        &mut self,
+    ) -> Result<impl Stream<Item = Result<T, CouchbaseError>>, CouchbaseError>
     where
         T: DeserializeOwned,
     {
-        self.rows.take().expect("Rows already consumed!").map(|v| {
-            let f = from_slice::<T>(v.as_slice());
-            match f {
-                Ok(r) => Ok(r),
-                Err(_) => Err(CouchbaseError::DecodingError),
-            }
-        })
+        if let Some(stream) = self.rows.take() {
+            return Ok(stream.map(|v| {
+                let f = from_slice::<T>(v.as_slice());
+                match f {
+                    Ok(r) => Ok(r),
+                    Err(e) => Err(CouchbaseError::DecodingError(e)),
+                }
+            }));
+        } else {
+            return Err(CouchbaseError::RowsConsumed);
+        }
     }
 
-    pub fn meta(&mut self) -> impl Future<Output = Result<QueryMeta, CouchbaseError>> {
-        self.meta
-            .take()
-            .expect("Meta already consumed!")
-            .map_ok(|v| from_slice::<QueryMeta>(v.as_slice()).expect("Could not convert type"))
-            .map_err(|_| CouchbaseError::FutureError) // cancelled
+    pub async fn meta(&mut self) -> Result<QueryMeta, CouchbaseError> {
+        match self.meta.take() {
+            Some(mv) => {
+                let rmv = mv.await?;
+                from_slice::<QueryMeta>(rmv.as_slice()).map_err(CouchbaseError::DecodingError)
+            },
+            None => Err(CouchbaseError::MetaConsumed)
+        }
     }
 }
 
@@ -189,25 +197,34 @@ impl AnalyticsResult {
         }
     }
 
-    pub fn rows_as<T>(&mut self) -> impl Stream<Item = Result<T, CouchbaseError>>
+    pub fn rows_as<T>(
+        &mut self,
+    ) -> Result<impl Stream<Item = Result<T, CouchbaseError>>, CouchbaseError>
     where
         T: DeserializeOwned,
     {
-        self.rows.take().expect("Rows already consumed!").map(|v| {
-            let f = from_slice::<T>(v.as_slice());
-            match f {
-                Ok(r) => Ok(r),
-                Err(_) => Err(CouchbaseError::DecodingError),
-            }
-        })
+        if let Some(stream) = self.rows.take() {
+            return Ok(stream.map(|v| {
+                let f = from_slice::<T>(v.as_slice());
+                match f {
+                    Ok(r) => Ok(r),
+                    Err(e) => Err(CouchbaseError::DecodingError(e)),
+                }
+            }));
+        } else {
+            return Err(CouchbaseError::RowsConsumed);
+        }
     }
 
-    pub fn meta(&mut self) -> impl Future<Output = Result<AnalyticsMeta, CouchbaseError>> {
-        self.meta
-            .take()
-            .expect("Meta already consumed!")
-            .map_ok(|v| from_slice::<AnalyticsMeta>(v.as_slice()).expect("Could not convert type"))
-            .map_err(|_| CouchbaseError::FutureError) // cancelled
+    pub async fn meta(&mut self) -> Result<AnalyticsMeta, CouchbaseError> {
+        match self.meta.take() {
+            Some(mv) => {
+                let rmv = mv.await?;
+                from_slice::<AnalyticsMeta>(rmv.as_slice()).map_err(CouchbaseError::DecodingError)
+
+            },
+            None => Err(CouchbaseError::MetaConsumed)
+        }
     }
 }
 


### PR DESCRIPTION
This commit switches from futures 0.1 to the new async/await syntax. It
requires Rust 1.39+, currently in beta. Additionally, it switches from
`std::sync::Mutex` to the futures-safe Mutex from `futures-preview`.
This should solve deadlock problems when running on multi-threaded
futures executors, such as tokio.

All tests pass, and the rustdoc is updated.