### PR TITLE
Scan consistency

### DIFF
--- a/couchbase/examples/query_scan_consistency.rs
+++ b/couchbase/examples/query_scan_consistency.rs
@@ -1,0 +1,35 @@
+use couchbase::options::{QueryOptions, ScanConsistency};
+use couchbase::{Cluster, CouchbaseError};
+use futures::executor::block_on;
+use futures::stream::StreamExt;
+use serde_json::{json, Value};
+
+use std::collections::HashMap;
+
+fn main() -> Result<(), CouchbaseError> {
+    env_logger::init();
+
+    let mut cluster = Cluster::connect("couchbase://127.0.0.1", "Administrator", "password")?;
+    let _ = cluster.bucket("travel-sample");
+
+    let f = async {
+        let query_options = QueryOptions::new().set_scan_consistency(ScanConsistency::RequestPlus);
+        let mut request_plus_result = cluster
+            .query(
+                "select name, type from `travel-sample` where name = 'Texas Wings'",
+                Some(query_options),
+            )
+            .await.expect("Had some data");
+
+        println!(
+            "Rows:\n{:?}",
+            request_plus_result
+                .rows_as().expect("rows consumed")
+                .collect::<Vec<Result<Value, CouchbaseError>>>().await
+        );
+        cluster.disconnect().expect("Could not shutdown properly");
+    };
+    block_on(f);
+    Ok(())
+}
+

--- a/couchbase/src/instance/request.rs
+++ b/couchbase/src/instance/request.rs
@@ -583,9 +583,13 @@ impl InstanceRequest for QueryRequest {
         let cookie = Box::into_raw(sender_boxed) as *mut c_void;
         unsafe {
             lcb_cmdn1ql_create(&mut command);
-            lcb_cmdn1ql_consistency(command, 2);
             lcb_cmdn1ql_statement(command, statement_encoded.as_ptr(), statement_len);
             if let Some(options) = self.options {
+                // NOTE: When the rest of SDK 3.0 is implemented, this will need to have a check
+                // for the `consistentWith(MutationState)`. For now, we aren't implmenting that
+                // feature.
+                lcb_cmdn1ql_consistency(command, options.scan_consistency() as u32);
+
                 if let Some(timeout) = options.timeout() {
                     lcb_cmdn1ql_timeout(command, timeout.as_millis() as u32);
                 }

--- a/couchbase/src/instance/request.rs
+++ b/couchbase/src/instance/request.rs
@@ -583,6 +583,7 @@ impl InstanceRequest for QueryRequest {
         let cookie = Box::into_raw(sender_boxed) as *mut c_void;
         unsafe {
             lcb_cmdn1ql_create(&mut command);
+            lcb_cmdn1ql_consistency(command, 2);
             lcb_cmdn1ql_statement(command, statement_encoded.as_ptr(), statement_len);
             if let Some(options) = self.options {
                 if let Some(timeout) = options.timeout() {

--- a/couchbase/src/result.rs
+++ b/couchbase/src/result.rs
@@ -103,24 +103,24 @@ pub struct QueryResult {
 #[derive(Debug, Deserialize)]
 pub struct QueryMeta {
     #[serde(rename = "requestID")]
-    request_id: String,
-    status: String,
-    metrics: QueryMetrics,
-    errors: Option<Value>,
+    pub request_id: String,
+    pub status: String,
+    pub metrics: QueryMetrics,
+    pub errors: Option<Value>,
     #[serde(rename = "clientContextID")]
-    client_context_id: String,
+    pub client_context_id: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct QueryMetrics {
     #[serde(rename = "elapsedTime")]
-    elapsed_time: String,
+    pub elapsed_time: String,
     #[serde(rename = "executionTime")]
-    execution_time: String,
+    pub execution_time: String,
     #[serde(rename = "resultCount")]
-    result_count: usize,
+    pub result_count: usize,
     #[serde(rename = "resultSize")]
-    result_size: usize,
+    pub result_size: usize,
 }
 
 impl QueryResult {


### PR DESCRIPTION
This fixes #53, along with exposing the query meta struct fields as public.

It does not implement all the possible query options; seems like we should let the C API stabilize first, and then do it all at once.