### PR TITLE
Tried to use couchbase in rust, found out that your cmake reference didn't support VISUAL STUDIO 2022

### DIFF
--- a/couchbase-sys/Cargo.toml
+++ b/couchbase-sys/Cargo.toml
@@ -18,7 +18,7 @@ openssl-sys = "0.9.58"
 
 [build-dependencies]
 cc = "1.0"
-cmake = "0.1.45"
+cmake = "0.1.48"
 
 [build-dependencies.bindgen]
 version = "0.55"

--- a/couchbase/integration/util/mock.rs
+++ b/couchbase/integration/util/mock.rs
@@ -193,7 +193,7 @@ async fn fetch_caves(path: &PathBuf, version: String) {
 }
 
 #[cfg(target_os = "windows")]
-fn set_permissions() {}
+fn set_permissions(_path: &PathBuf) {}//have same parameterlist
 
 #[cfg(not(target_os = "windows"))]
 fn set_permissions(path: &PathBuf) {

--- a/couchbase/src/api/subdoc_results.rs
+++ b/couchbase/src/api/subdoc_results.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::io::couchbase_error_from_lcb_status;
 use crate::{CouchbaseError, CouchbaseResult, ErrorContext};
 
@@ -47,8 +49,12 @@ impl LookupInResult {
         match content.status {
             0 => {}
             _ => {
+                let status_i32_check = content.status.try_into();
+                if status_i32_check.is_err(){
+                    panic!("could not convert content.status value of {} into i32",content.status);
+                }
                 return Err(couchbase_error_from_lcb_status(
-                    content.status,
+                    status_i32_check.unwrap(),
                     ErrorContext::default(),
                 ))
             }

--- a/couchbase/src/io/lcb/callbacks.rs
+++ b/couchbase/src/io/lcb/callbacks.rs
@@ -8,6 +8,7 @@ use crate::{
 use couchbase_sys::*;
 use log::{debug, trace};
 use serde_json::Value;
+use std::convert::TryInto;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_uint, c_void};
 use std::ptr;
@@ -373,8 +374,12 @@ pub unsafe extern "C" fn lookup_in_callback(
             let mut value_ptr: *const c_char = ptr::null();
             lcb_respsubdoc_result_value(subdoc_res, i, &mut value_ptr, &mut value_len);
             let value = from_raw_parts(value_ptr as *const u8, value_len);
+            let status_u32_check = status.try_into();
+            if status_u32_check.is_err(){
+                panic!("Could not convert status value {} into u32",status);
+            }
             fields.push(SubDocField {
-                status,
+                status: status_u32_check.unwrap(),
                 value: value.into(),
             });
         }
@@ -418,8 +423,12 @@ pub unsafe extern "C" fn mutate_in_callback(
             let mut value_ptr: *const c_char = ptr::null();
             lcb_respsubdoc_result_value(subdoc_res, i, &mut value_ptr, &mut value_len);
             let value = from_raw_parts(value_ptr as *const u8, value_len);
+            let status_u32_check = status.try_into();
+            if status_u32_check.is_err(){
+                panic!("Could not convert status value {} into u32",status);
+            }
             fields.push(SubDocField {
-                status,
+                status : status_u32_check.unwrap(),
                 value: value.into(),
             });
         }


### PR DESCRIPTION
The depedency of cmake ist updated to 0.1.48 so that Visual Studio 2022 is support.

still unable to compile your code example "couchbase.lib" could nocht be opened