### PR TITLE
fix: `__va_list_tag` not found

### DIFF
--- a/couchbase/src/api/search.rs
+++ b/couchbase/src/api/search.rs
@@ -1,4 +1,3 @@
-use serde::Serialize;
 use serde_derive::Serialize;
 use serde_json::json;
 use std::fmt::Debug;
@@ -1078,7 +1077,7 @@ impl SearchQuery for GeoPolygonQuery {
     }
 }
 
-pub trait SearchSort: Serialize {}
+pub trait SearchSort: serde::Serialize {}
 
 #[derive(Debug, Serialize)]
 pub struct SearchSortScore {
@@ -1261,7 +1260,7 @@ impl SearchSortGeoDistance {
 
 impl SearchSort for SearchSortGeoDistance {}
 
-pub trait SearchFacet: Serialize {}
+pub trait SearchFacet: serde::Serialize {}
 
 #[derive(Debug, Serialize)]
 pub struct TermFacet {

--- a/couchbase/src/api/search_indexes.rs
+++ b/couchbase/src/api/search_indexes.rs
@@ -3,7 +3,6 @@ use crate::io::Core;
 use crate::{CouchbaseError, CouchbaseResult, ErrorContext, GenericManagementResult, ServiceType};
 use futures::channel::oneshot;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -41,7 +40,7 @@ impl SearchIndexBuilder {
 
     pub fn params<T>(mut self, params: HashMap<String, T>) -> CouchbaseResult<Self>
     where
-        T: Serialize,
+        T: serde::Serialize,
     {
         self.params =
             Some(
@@ -61,7 +60,7 @@ impl SearchIndexBuilder {
 
     pub fn source_params<T>(mut self, params: HashMap<String, T>) -> CouchbaseResult<Self>
     where
-        T: Serialize,
+        T: serde::Serialize,
     {
         self.source_params =
             Some(
@@ -81,7 +80,7 @@ impl SearchIndexBuilder {
 
     pub fn plan_params<T>(mut self, params: HashMap<String, T>) -> CouchbaseResult<Self>
     where
-        T: Serialize,
+        T: serde::Serialize,
     {
         self.plan_params =
             Some(
@@ -198,7 +197,7 @@ impl SearchIndex {
 
     pub fn set_params<T>(&mut self, params: HashMap<String, T>) -> CouchbaseResult<()>
     where
-        T: Serialize,
+        T: serde::Serialize,
     {
         self.params = Some(
             serde_json::to_value(params).map_err(CouchbaseError::encoding_failure_from_serde)?,
@@ -213,7 +212,7 @@ impl SearchIndex {
 
     pub fn set_source_params<T>(&mut self, params: HashMap<String, T>) -> CouchbaseResult<()>
     where
-        T: Serialize,
+        T: serde::Serialize,
     {
         self.source_params = Some(
             serde_json::to_value(params).map_err(CouchbaseError::encoding_failure_from_serde)?,
@@ -228,7 +227,7 @@ impl SearchIndex {
 
     pub fn set_plan_params<T>(&mut self, params: HashMap<String, T>) -> CouchbaseResult<()>
     where
-        T: Serialize,
+        T: serde::Serialize,
     {
         self.plan_params = Some(
             serde_json::to_value(params).map_err(CouchbaseError::encoding_failure_from_serde)?,
@@ -496,7 +495,7 @@ impl SearchIndexManager {
         opts: impl Into<Option<AnalyzeDocumentSearchIndexOptions>>,
     ) -> CouchbaseResult<T>
     where
-        I: Serialize,
+        I: serde::Serialize,
         T: DeserializeOwned,
     {
         let opts = unwrap_or_default!(opts.into());

--- a/couchbase/src/io/lcb/mod.rs
+++ b/couchbase/src/io/lcb/mod.rs
@@ -145,8 +145,13 @@ fn run_lcb_loop(
 /// Note that libcouchbase still wants to own the buffer, so we can only look into the
 /// returned opaque str and clone it into ownership before return.
 fn bucket_name_for_instance(instance: *mut lcb_INSTANCE) -> Option<String> {
-    let mut bucket_ptr: *mut i8 = ptr::null_mut();
-    let opaque_ptr = &mut bucket_ptr as *mut *mut i8;
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    type Num = u8;
+    #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
+    type Num = i8;
+
+    let mut bucket_ptr: *mut Num = ptr::null_mut();
+    let opaque_ptr = &mut bucket_ptr as *mut *mut Num;
 
     unsafe {
         let status = lcb_cntl(


### PR DESCRIPTION
## Overview 

This PR solves to issues I faced during building and compiling `couchbase-rs` on macos M1 and rust 1.65.0:

- `__va_list_tag` not found in this scope
- `serde::Serialize` and `serde_derive::Serialize` naming conflict

## Details

When trying to build `couchbase-rs` on macbook m1 or arm64-based docker image. The build process errors with: 

```bash
error[E0412]: cannot find type `__va_list_tag` in this scope
    --> couchbase/src/io/lcb/callbacks.rs:1035:31
     |
1035 | pub(crate) type VaList = *mut __va_list_tag;
     |                               ^^^^^^^^^^^^^ not found in this scope
```

Additionally, when trying to integrate `couchbase-rs` in a rust project, I get Serialize macro/struct name conflict errors.

## Solution

1. **Guard `VaList` definition with extra `target_os` and `target_arch` conditions**
    If `target_arch` is either "arch64" or "arm64" then `VaList` will be defined as `va_list`.
    else it should not effect the original configurations.
2. **Expect `u8` or `i8` while building for arm64**
   if `target_arch` == "aarch64" and it's linux then `u8` else `i8`


cc @chvck
