### PR TITLE
fix: library not found

### DIFF
--- a/couchbase-sys/build/main.rs
+++ b/couchbase-sys/build/main.rs
@@ -60,6 +60,11 @@ fn main() {
 
     let build_dst = build_cfg.build();
 
+    println!(
+        "cargo:rustc-link-search=native={}",
+        build_dst.join("build/lib").display()
+    );
+
     if cfg!(feature = "link-static") {
         if cfg!(target_os = "windows") {
             if env::var("PROFILE").unwrap() == "release" {


### PR DESCRIPTION
## Overview

This PR solves an issue I faced while running the kv example under macOS M1 and rust 1.65.0:

I have the following installed:

- clang `v11.1.0`
- cmake `v3.24.3`
- pkg-config `v0.29.2`
- openssl `v3.0.7`
- libevent `2.1.12`
- libiconv `v2.35`

## Problem

Running with default features:

```
error: linking with `cc` failed: exit status: 1 ... ld: library not found for -lcouchbase
```
Running with default features + libcouchbase-static:
```
error: could not find native static library `couchbase`, perhaps an -L flag is missing?
```
## Soltuion

Let rustc know the location of libcouchbase library

```rust
println!(
    "cargo:rustc-link-search=native={}",
    build_dst.join("build/lib").display()
);
```

## NOTES

- Tried to run tests, however, `Success: 0, Failures: 26, Skipped:`. most errors `Cannot dispatch operation because no open bucket found` is there a script for preparing couchbase server for rust tests?
