### PR TITLE
Rework memdx error model

### DIFF
--- a/sdk/couchbase-core/src/cbconfig/mod.rs
+++ b/sdk/couchbase-core/src/cbconfig/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct VBucketServerMap {
     #[serde(alias = "hashAlgorithm")]
     pub hash_algorithm: String,
@@ -14,13 +14,13 @@ pub struct VBucketServerMap {
     pub vbucket_map: Vec<Vec<i16>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ConfigDDocs {
     #[serde(alias = "uri")]
     pub uri: String,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct TerseExtNodePorts {
     #[serde(alias = "kv")]
     pub kv: Option<i64>,
@@ -61,7 +61,7 @@ pub struct TerseExtNodePorts {
     pub backup_ssl: Option<i64>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TerseExtNodeAltAddresses {
     #[serde(alias = "ports")]
     pub ports: TerseExtNodePorts,
@@ -69,7 +69,7 @@ pub struct TerseExtNodeAltAddresses {
     pub hostname: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TerseNodePorts {
     #[serde(alias = "direct")]
     pub direct: Option<u16>,
@@ -77,7 +77,7 @@ pub struct TerseNodePorts {
     pub proxy: Option<u16>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TerseNodeConfig {
     #[serde(alias = "couchbaseApiBase")]
     pub couchbase_api_base: Option<String>,
@@ -87,7 +87,7 @@ pub struct TerseNodeConfig {
     pub ports: Option<TerseNodePorts>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TerseNodeExtConfig {
     #[serde(alias = "services")]
     pub services: Option<TerseExtNodePorts>,
@@ -99,7 +99,7 @@ pub struct TerseNodeExtConfig {
     pub alternate_addresses: HashMap<String, TerseExtNodeAltAddresses>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TerseConfig {
     #[serde(alias = "rev")]
     pub rev: i64,

--- a/sdk/couchbase-core/src/error.rs
+++ b/sdk/couchbase-core/src/error.rs
@@ -1,22 +1,22 @@
 use std::fmt::Display;
 
 use crate::error::CoreError::{Dispatch, Placeholder, PlaceholderMemdxWrapper};
-use crate::memdx::error::MemdxError;
+use crate::memdx::error::{Error, ErrorKind};
 
-#[derive(thiserror::Error, Debug, Eq, PartialEq)]
+#[derive(thiserror::Error, Debug)]
 pub enum CoreError {
     #[error("Dispatch error {0}")]
-    Dispatch(MemdxError),
+    Dispatch(Error),
     #[error("Placeholder error {0}")]
     Placeholder(String),
     #[error("Placeholder memdx wrapper error {0}")]
-    PlaceholderMemdxWrapper(MemdxError),
+    PlaceholderMemdxWrapper(Error),
 }
 
-impl From<MemdxError> for CoreError {
-    fn from(value: MemdxError) -> Self {
-        match value {
-            MemdxError::Dispatch(_) => Dispatch(value),
+impl From<Error> for CoreError {
+    fn from(value: Error) -> Self {
+        match value.kind.as_ref() {
+            ErrorKind::Dispatch(_) => Dispatch(value),
             _ => PlaceholderMemdxWrapper(value),
         }
     }

--- a/sdk/couchbase-core/src/kvclient.rs
+++ b/sdk/couchbase-core/src/kvclient.rs
@@ -176,7 +176,7 @@ where
         }
 
         let (connection_close_tx, mut connection_close_rx) =
-            oneshot::channel::<crate::memdx::client::MemdxResult<()>>();
+            oneshot::channel::<crate::memdx::error::Result<()>>();
         let memdx_client_opts = DispatcherOptions {
             on_connection_close_handler: Some(connection_close_tx),
             orphan_handler: opts.orphan_handler,

--- a/sdk/couchbase-core/src/memdx/auth_mechanism.rs
+++ b/sdk/couchbase-core/src/memdx/auth_mechanism.rs
@@ -1,4 +1,4 @@
-use crate::memdx::error::MemdxError;
+use crate::memdx::error::{Error, ErrorKind};
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum AuthMechanism {
@@ -22,7 +22,7 @@ impl From<AuthMechanism> for Vec<u8> {
 }
 
 impl TryFrom<&str> for AuthMechanism {
-    type Error = MemdxError;
+    type Error = Error;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let mech = match value {
@@ -31,10 +31,10 @@ impl TryFrom<&str> for AuthMechanism {
             "SCRAM-SHA256" => AuthMechanism::ScramSha256,
             "SCRAM-SHA512" => AuthMechanism::ScramSha512,
             _ => {
-                return Err(MemdxError::Protocol(format!(
-                    "Unknown auth mechanism {}",
-                    value
-                )));
+                return Err(ErrorKind::Protocol {
+                    msg: format!("Unknown auth mechanism {}", value),
+                }
+                .into());
             }
         };
 

--- a/sdk/couchbase-core/src/memdx/dispatcher.rs
+++ b/sdk/couchbase-core/src/memdx/dispatcher.rs
@@ -4,20 +4,20 @@ use async_trait::async_trait;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
-use crate::memdx::client::MemdxResult;
 use crate::memdx::connection::Connection;
+use crate::memdx::error::Result;
 use crate::memdx::packet::{RequestPacket, ResponsePacket};
 use crate::memdx::pendingop::ClientPendingOp;
 
 #[derive(Debug)]
 pub struct DispatcherOptions {
     pub orphan_handler: Arc<UnboundedSender<ResponsePacket>>,
-    pub on_connection_close_handler: Option<oneshot::Sender<MemdxResult<()>>>,
+    pub on_connection_close_handler: Option<oneshot::Sender<Result<()>>>,
 }
 
 #[async_trait]
 pub trait Dispatcher: Send + Sync {
     fn new(conn: Connection, opts: DispatcherOptions) -> Self;
-    async fn dispatch(&self, packet: RequestPacket) -> MemdxResult<ClientPendingOp>;
-    async fn close(&self) -> MemdxResult<()>;
+    async fn dispatch(&self, packet: RequestPacket) -> Result<ClientPendingOp>;
+    async fn close(&self) -> Result<()>;
 }

--- a/sdk/couchbase-core/src/memdx/error.rs
+++ b/sdk/couchbase-core/src/memdx/error.rs
@@ -1,22 +1,85 @@
-use std::fmt::{Display, Formatter};
+use std::fmt::{Display, Formatter, Pointer};
 use std::io;
+use std::sync::Arc;
 
+use thiserror::Error;
 use tokio::time::error::Elapsed;
 
+use crate::memdx::error;
+use crate::memdx::status::Status;
 use crate::scram::ScramError;
 
-#[derive(thiserror::Error, Debug, Eq, PartialEq)]
-pub enum MemdxError {
-    #[error("Connect failed {0}")]
-    Connect(io::ErrorKind),
-    #[error("Dispatch failed {0}")]
-    Dispatch(io::ErrorKind),
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Clone, Debug, Error)]
+#[error("{kind}")]
+#[non_exhaustive]
+pub struct Error {
+    /// Taken from serde_json: This `Box` allows us to keep the size of `Error` as small as possible.
+    /// A larger `Error` type was substantially slower due to all the functions
+    /// that pass around `Result<T, Error>`.
+    pub kind: Box<ErrorKind>,
+}
+
+#[derive(Clone, Debug, Error)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    #[error("{0:?}")]
+    Server(ServerError),
+    #[error("Dispatch failed {0:?}")]
+    #[non_exhaustive]
+    Dispatch(Arc<io::Error>),
+    #[error("Protocol error {msg}")]
+    #[non_exhaustive]
+    Protocol { msg: String },
+    #[error("Connect error {0}")]
+    Connect(Arc<io::Error>),
     #[error("Request cancelled {0}")]
     Cancelled(CancellationErrorKind),
+    #[error("Connection closed")]
+    Closed,
+    #[error("Unknown bucket name")]
+    UnknownBucketName,
+    #[error("Unknown IO error {0:?}")]
+    #[non_exhaustive]
+    Io(Arc<io::Error>),
+    #[error("Invalid argument {msg}")]
+    #[non_exhaustive]
+    InvalidArgument { msg: String },
+}
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[error("Server error: {kind}")]
+#[non_exhaustive]
+pub struct ServerError {
+    pub kind: ServerErrorKind,
+    pub config: Option<Vec<u8>>,
+    pub context: Option<ServerErrorContext>,
+}
+
+impl ServerError {
+    pub(crate) fn new(kind: ServerErrorKind) -> Self {
+        Self {
+            kind,
+            config: None,
+            context: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ServerErrorContext {
+    pub text: String,
+    pub error_ref: String,
+    pub manifest_rev: u64,
+}
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum ServerErrorKind {
     #[error("Not my vbucket")]
     NotMyVbucket,
-    #[error("Protocol error {0}")]
-    Protocol(String),
     #[error("Key exists")]
     KeyExists,
     #[error("Key not found")]
@@ -27,60 +90,105 @@ pub enum MemdxError {
     Locked,
     #[error("Too big")]
     TooBig,
-    #[error("Collections not enabled")]
-    CollectionsNotEnabled,
     #[error("Unknown collection id")]
     UnknownCollectionID,
     #[error("Unknown bucket name")]
     UnknownBucketName,
     #[error("Access error")]
     Access,
-    #[error("Auth error")]
-    Auth(String),
-    #[error("Connection closed")]
-    Closed,
+    #[error("Auth error {msg}")]
+    Auth { msg: String },
     #[error("Config not set")]
     ConfigNotSet,
-    #[error("Closed in flight")]
-    ClosedInFlight,
-    #[error("{0}")]
-    Generic(String),
-    #[error("Unknown error {0}")]
-    Unknown(String),
+    #[error("Server status unexpected for operation: {status}")]
+    UnknownStatus { status: Status },
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
 pub enum CancellationErrorKind {
     Timeout,
     RequestCancelled,
+    ClosedInFlight,
+}
+
+impl Error {
+    pub(crate) fn new_protocol_error(msg: &str) -> Self {
+        Self {
+            kind: Box::new(ErrorKind::Protocol { msg: msg.into() }),
+        }
+    }
+
+    pub fn has_server_config(&self) -> Option<&Vec<u8>> {
+        if let ErrorKind::Server(ServerError { config, .. }) = self.kind.as_ref() {
+            config.as_ref()
+        } else {
+            None
+        }
+    }
+
+    pub fn has_server_error_context(&self) -> Option<&ServerErrorContext> {
+        if let ErrorKind::Server(ServerError { context, .. }) = self.kind.as_ref() {
+            context.as_ref()
+        } else {
+            None
+        }
+    }
 }
 
 impl Display for CancellationErrorKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let txt = match self {
-            CancellationErrorKind::Timeout => "timeout",
-            CancellationErrorKind::RequestCancelled => "request cancelled",
+            CancellationErrorKind::Timeout => "Timeout",
+            CancellationErrorKind::RequestCancelled => "Request cancelled",
+            CancellationErrorKind::ClosedInFlight => "Closed in flight",
         };
 
         write!(f, "{}", txt)
     }
 }
 
-// TODO: improve this.
-impl From<io::Error> for MemdxError {
+impl<E> From<E> for Error
+where
+    ErrorKind: From<E>,
+{
+    fn from(err: E) -> Self {
+        Self {
+            kind: Box::new(err.into()),
+        }
+    }
+}
+
+impl From<ServerErrorKind> for Error {
+    fn from(kind: ServerErrorKind) -> Self {
+        Self {
+            kind: Box::new(ErrorKind::Server(ServerError::new(kind))),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
     fn from(value: io::Error) -> Self {
-        MemdxError::Unknown(value.to_string())
+        Self {
+            kind: Box::new(ErrorKind::Io(Arc::new(value))),
+        }
     }
 }
 
-impl From<ScramError> for MemdxError {
+impl From<ScramError> for Error {
     fn from(value: ScramError) -> Self {
-        Self::Auth(value.to_string())
+        Self {
+            kind: Box::new(ErrorKind::Server(ServerError::new(ServerErrorKind::Auth {
+                msg: value.to_string(),
+            }))),
+        }
     }
 }
 
-impl From<Elapsed> for MemdxError {
+impl From<Elapsed> for Error {
     fn from(_value: Elapsed) -> Self {
-        Self::Cancelled(CancellationErrorKind::Timeout)
+        Self {
+            kind: Box::new(ErrorKind::Cancelled(CancellationErrorKind::Timeout)),
+        }
     }
 }

--- a/sdk/couchbase-core/src/memdx/magic.rs
+++ b/sdk/couchbase-core/src/memdx/magic.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use crate::memdx::error::MemdxError;
+use crate::memdx::error::{Error, ErrorKind};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Magic {
@@ -36,7 +36,7 @@ impl From<Magic> for u8 {
 }
 
 impl TryFrom<u8> for Magic {
-    type Error = MemdxError;
+    type Error = Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         let magic = match value {
@@ -45,7 +45,10 @@ impl TryFrom<u8> for Magic {
             0x08 => Magic::ReqExt,
             0x18 => Magic::ResExt,
             _ => {
-                return Err(MemdxError::Protocol(format!("unknown magic {}", value)));
+                return Err(ErrorKind::Protocol {
+                    msg: format!("unknown magic {}", value),
+                }
+                .into());
             }
         };
 

--- a/sdk/couchbase-core/src/memdx/op_auth_saslbyname.rs
+++ b/sdk/couchbase-core/src/memdx/op_auth_saslbyname.rs
@@ -1,8 +1,8 @@
 use tokio::time::Instant;
 
 use crate::memdx::auth_mechanism::AuthMechanism;
-use crate::memdx::client::MemdxResult;
 use crate::memdx::dispatcher::Dispatcher;
+use crate::memdx::error::Result;
 use crate::memdx::op_auth_saslplain::{OpSASLPlainEncoder, OpsSASLAuthPlain, SASLAuthPlainOptions};
 use crate::memdx::op_auth_saslscram::{OpSASLScramEncoder, OpsSASLAuthScram, SASLAuthScramOptions};
 
@@ -27,7 +27,7 @@ impl OpsSASLAuthByName {
         encoder: &E,
         dispatcher: &D,
         opts: SASLAuthByNameOptions,
-    ) -> MemdxResult<()>
+    ) -> Result<()>
     where
         E: OpSASLAuthByNameEncoder,
         D: Dispatcher,

--- a/sdk/couchbase-core/src/memdx/op_auth_saslscram.rs
+++ b/sdk/couchbase-core/src/memdx/op_auth_saslscram.rs
@@ -4,9 +4,9 @@ use sha2::{Sha256, Sha512};
 use tokio::time::Instant;
 
 use crate::memdx::auth_mechanism::AuthMechanism;
-use crate::memdx::client::MemdxResult;
 use crate::memdx::dispatcher::Dispatcher;
-use crate::memdx::error::MemdxError;
+use crate::memdx::error::ErrorKind;
+use crate::memdx::error::Result;
 use crate::memdx::op_auth_saslplain::OpSASLPlainEncoder;
 use crate::memdx::pendingop::{run_op_future_with_deadline, StandardPendingOp};
 use crate::memdx::request::{SASLAuthRequest, SASLStepRequest};
@@ -18,7 +18,7 @@ pub trait OpSASLScramEncoder: OpSASLPlainEncoder {
         &self,
         dispatcher: &D,
         request: SASLStepRequest,
-    ) -> impl std::future::Future<Output = MemdxResult<StandardPendingOp<SASLStepResponse>>>
+    ) -> impl std::future::Future<Output = Result<StandardPendingOp<SASLStepResponse>>>
     where
         D: Dispatcher;
 }
@@ -52,7 +52,7 @@ impl OpsSASLAuthScram {
         encoder: &E,
         dispatcher: &D,
         opts: SASLAuthScramOptions,
-    ) -> MemdxResult<()>
+    ) -> Result<()>
     where
         E: OpSASLScramEncoder,
         D: Dispatcher,
@@ -86,9 +86,10 @@ impl OpsSASLAuthScram {
             run_op_future_with_deadline(opts.deadline, encoder.sasl_step(dispatcher, req)).await?;
 
         if resp.needs_more_steps {
-            return Err(MemdxError::Protocol(
-                "Server did not accept auth when the client expected".to_string(),
-            ));
+            return Err(ErrorKind::Protocol {
+                msg: "Server did not accept auth when the client expected".to_string(),
+            }
+            .into());
         }
 
         Ok(())
@@ -99,7 +100,7 @@ impl OpsSASLAuthScram {
         encoder: &E,
         dispatcher: &D,
         opts: SASLAuthScramOptions,
-    ) -> MemdxResult<()>
+    ) -> Result<()>
     where
         E: OpSASLScramEncoder,
         D: Dispatcher,
@@ -133,9 +134,10 @@ impl OpsSASLAuthScram {
             run_op_future_with_deadline(opts.deadline, encoder.sasl_step(dispatcher, req)).await?;
 
         if resp.needs_more_steps {
-            return Err(MemdxError::Protocol(
-                "Server did not accept auth when the client expected".to_string(),
-            ));
+            return Err(ErrorKind::Protocol {
+                msg: "Server did not accept auth when the client expected".to_string(),
+            }
+            .into());
         }
 
         Ok(())
@@ -146,7 +148,7 @@ impl OpsSASLAuthScram {
         encoder: &E,
         dispatcher: &D,
         opts: SASLAuthScramOptions,
-    ) -> MemdxResult<()>
+    ) -> Result<()>
     where
         E: OpSASLScramEncoder,
         D: Dispatcher,
@@ -179,9 +181,10 @@ impl OpsSASLAuthScram {
             run_op_future_with_deadline(opts.deadline, encoder.sasl_step(dispatcher, req)).await?;
 
         if resp.needs_more_steps {
-            return Err(MemdxError::Protocol(
-                "Server did not accept auth when the client expected".to_string(),
-            ));
+            return Err(ErrorKind::Protocol {
+                msg: "Server did not accept auth when the client expected".to_string(),
+            }
+            .into());
         }
 
         Ok(())

--- a/sdk/couchbase-core/src/memdx/op_bootstrap.rs
+++ b/sdk/couchbase-core/src/memdx/op_bootstrap.rs
@@ -2,9 +2,9 @@ use log::warn;
 use tokio::select;
 use tokio::time::{Instant, sleep};
 
-use crate::memdx::client::MemdxResult;
 use crate::memdx::dispatcher::Dispatcher;
 use crate::memdx::error::CancellationErrorKind;
+use crate::memdx::error::Result;
 use crate::memdx::op_auth_saslauto::{OpSASLAutoEncoder, OpsSASLAuthAuto, SASLAuthAutoOptions};
 use crate::memdx::op_auth_saslplain::OpSASLPlainEncoder;
 use crate::memdx::pendingop::{PendingOp, run_op_future_with_deadline, StandardPendingOp};
@@ -22,7 +22,7 @@ pub trait OpBootstrapEncoder {
         &self,
         dispatcher: &D,
         request: HelloRequest,
-    ) -> impl std::future::Future<Output = MemdxResult<StandardPendingOp<HelloResponse>>>
+    ) -> impl std::future::Future<Output = Result<StandardPendingOp<HelloResponse>>>
     where
         D: Dispatcher;
 
@@ -30,7 +30,7 @@ pub trait OpBootstrapEncoder {
         &self,
         dispatcher: &D,
         request: GetErrorMapRequest,
-    ) -> impl std::future::Future<Output = MemdxResult<StandardPendingOp<GetErrorMapResponse>>>
+    ) -> impl std::future::Future<Output = Result<StandardPendingOp<GetErrorMapResponse>>>
     where
         D: Dispatcher;
 
@@ -38,7 +38,7 @@ pub trait OpBootstrapEncoder {
         &self,
         dispatcher: &D,
         request: SelectBucketRequest,
-    ) -> impl std::future::Future<Output = MemdxResult<StandardPendingOp<SelectBucketResponse>>>
+    ) -> impl std::future::Future<Output = Result<StandardPendingOp<SelectBucketResponse>>>
     where
         D: Dispatcher;
 
@@ -46,7 +46,7 @@ pub trait OpBootstrapEncoder {
         &self,
         dispatcher: &D,
         request: GetClusterConfigRequest,
-    ) -> impl std::future::Future<Output = MemdxResult<StandardPendingOp<GetClusterConfigResponse>>>
+    ) -> impl std::future::Future<Output = Result<StandardPendingOp<GetClusterConfigResponse>>>
     where
         D: Dispatcher;
 }
@@ -70,7 +70,7 @@ impl OpBootstrap {
         encoder: E,
         dispatcher: &D,
         opts: BootstrapOptions,
-    ) -> MemdxResult<BootstrapResult>
+    ) -> Result<BootstrapResult>
     where
         E: OpBootstrapEncoder + OpSASLAutoEncoder,
         D: Dispatcher,

--- a/sdk/couchbase-core/src/memdx/ops_core.rs
+++ b/sdk/couchbase-core/src/memdx/ops_core.rs
@@ -2,9 +2,9 @@ use std::io::Write;
 
 use byteorder::{BigEndian, WriteBytesExt};
 
-use crate::memdx::client::MemdxResult;
 use crate::memdx::dispatcher::Dispatcher;
-use crate::memdx::error::MemdxError;
+use crate::memdx::error::{Error, ServerErrorKind};
+use crate::memdx::error::Result;
 use crate::memdx::magic::Magic;
 use crate::memdx::op_auth_saslauto::OpSASLAutoEncoder;
 use crate::memdx::op_auth_saslbyname::OpSASLAuthByNameEncoder;
@@ -27,14 +27,14 @@ use crate::memdx::status::Status;
 pub struct OpsCore {}
 
 impl OpsCore {
-    pub(crate) fn decode_error(resp: &ResponsePacket) -> MemdxError {
+    pub(crate) fn decode_error(resp: &ResponsePacket) -> Error {
         let status = resp.status;
         if status == Status::NotMyVbucket {
-            MemdxError::NotMyVbucket
+            ServerErrorKind::NotMyVbucket.into()
         } else if status == Status::TmpFail {
-            MemdxError::TmpFail
+            ServerErrorKind::TmpFail.into()
         } else {
-            MemdxError::Unknown(format!("{}", status))
+            ServerErrorKind::UnknownStatus { status }.into()
         }
 
         // TODO: decode error context
@@ -46,7 +46,7 @@ impl OpBootstrapEncoder for OpsCore {
         &self,
         dispatcher: &D,
         request: HelloRequest,
-    ) -> MemdxResult<StandardPendingOp<HelloResponse>>
+    ) -> Result<StandardPendingOp<HelloResponse>>
     where
         D: Dispatcher,
     {
@@ -77,7 +77,7 @@ impl OpBootstrapEncoder for OpsCore {
         &self,
         dispatcher: &D,
         request: GetErrorMapRequest,
-    ) -> MemdxResult<StandardPendingOp<GetErrorMapResponse>>
+    ) -> Result<StandardPendingOp<GetErrorMapResponse>>
     where
         D: Dispatcher,
     {
@@ -106,7 +106,7 @@ impl OpBootstrapEncoder for OpsCore {
         &self,
         dispatcher: &D,
         request: SelectBucketRequest,
-    ) -> MemdxResult<StandardPendingOp<SelectBucketResponse>>
+    ) -> Result<StandardPendingOp<SelectBucketResponse>>
     where
         D: Dispatcher,
     {
@@ -135,7 +135,7 @@ impl OpBootstrapEncoder for OpsCore {
         &self,
         dispatcher: &D,
         _request: GetClusterConfigRequest,
-    ) -> MemdxResult<StandardPendingOp<GetClusterConfigResponse>>
+    ) -> Result<StandardPendingOp<GetClusterConfigResponse>>
     where
         D: Dispatcher,
     {
@@ -163,7 +163,7 @@ impl OpSASLPlainEncoder for OpsCore {
         &self,
         dispatcher: &D,
         request: SASLAuthRequest,
-    ) -> MemdxResult<StandardPendingOp<SASLAuthResponse>>
+    ) -> Result<StandardPendingOp<SASLAuthResponse>>
     where
         D: Dispatcher,
     {
@@ -196,7 +196,7 @@ impl OpSASLAutoEncoder for OpsCore {
         &self,
         dispatcher: &D,
         _request: SASLListMechsRequest,
-    ) -> MemdxResult<StandardPendingOp<SASLListMechsResponse>>
+    ) -> Result<StandardPendingOp<SASLListMechsResponse>>
     where
         D: Dispatcher,
     {
@@ -224,7 +224,7 @@ impl OpSASLScramEncoder for OpsCore {
         &self,
         dispatcher: &D,
         request: SASLStepRequest,
-    ) -> MemdxResult<StandardPendingOp<SASLStepResponse>>
+    ) -> Result<StandardPendingOp<SASLStepResponse>>
     where
         D: Dispatcher,
     {

--- a/sdk/couchbase-core/src/memdx/sync_helpers.rs
+++ b/sdk/couchbase-core/src/memdx/sync_helpers.rs
@@ -1,13 +1,13 @@
 use std::future::Future;
 
-use crate::memdx::client::MemdxResult;
+use crate::memdx::error::Result;
 use crate::memdx::pendingop::{PendingOp, StandardPendingOp};
 use crate::memdx::response::TryFromClientResponse;
 
-pub async fn sync_unary_call<RespT, Fut>(fut: Fut) -> MemdxResult<RespT>
+pub async fn sync_unary_call<RespT, Fut>(fut: Fut) -> Result<RespT>
 where
     RespT: TryFromClientResponse,
-    Fut: Future<Output = MemdxResult<StandardPendingOp<RespT>>>,
+    Fut: Future<Output = Result<StandardPendingOp<RespT>>>,
 {
     let mut op = fut.await?;
 


### PR DESCRIPTION
Motivation
----------
The memdx error model does not currently satisfy what we need from it. We need to be able to attach cluster configs and error context to errors sometimes.

Changes
--------
Rework memdx error model to include more types of error and the top level error be a struct.