### PR TITLE
Move to nightly rust to access async closures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Update Rust Toolchain Target
+        run: |
+          echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
+
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.4.3
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/sdk/couchbase-core/src/kvclientmanager.rs
+++ b/sdk/couchbase-core/src/kvclientmanager.rs
@@ -239,10 +239,8 @@ where
         let client = manager.get_client(endpoint.clone()).await?;
 
         let res = operation(client.clone()).await;
-        match res {
-            Ok(r) => {
-                return Ok(r);
-            }
+        return match res {
+            Ok(r) => Ok(r),
             Err(e) => {
                 if let Some(memdx_err) = e.is_memdx_error() {
                     if memdx_err.is_dispatch_error() {
@@ -257,20 +255,9 @@ where
                     }
                 }
 
-                return Err(e);
+                Err(e)
             }
-        }
-    }
-}
-
-pub(crate) struct OrchestrateMemdClientAsyncFnMut {}
-
-impl OrchestrateMemdClientAsyncFnMut {
-    async fn call<K, Resp: TryFromClientResponse>(&mut self, client: Arc<K>) -> Result<Resp>
-    where
-        K: KvClient + KvClientOps + PartialEq + Sync + Send + 'static,
-    {
-        todo!()
+        };
     }
 }
 
@@ -357,7 +344,7 @@ mod tests {
         let result = orchestrate_memd_client(
             &manager,
             "192.168.107.128:11210".to_string(),
-            |client: Arc<StdKvClient<Client>>| async move {
+            async |client: Arc<StdKvClient<Client>>| {
                 client
                     .set(SetRequest {
                         collection_id: 0,
@@ -379,7 +366,7 @@ mod tests {
         .await
         .unwrap();
 
-        dbg!(result);
+        // dbg!(result);
 
         let client = manager
             .get_client("192.168.107.128:11210".to_string())

--- a/sdk/couchbase-core/src/lib.rs
+++ b/sdk/couchbase-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(async_closure)]
+
 pub mod authenticator;
 pub mod cbconfig;
 mod configparser;


### PR DESCRIPTION
Motivation
----------
A primary design pattern that we want to use is currently challenging due to asybc closures not being supported in stable rust. In order to make this pattern possible we should switch to nightly and enable the feature. async_closures should be moved to stable before we need to release the SDK.

Changes
--------
Specify the nightly toolchain.
Enable async_closures feature.
Use async closures.