### PR TITLE
Change authenticator to be an enum

### DIFF
--- a/sdk/couchbase-core/src/authenticator.rs
+++ b/sdk/couchbase-core/src/authenticator.rs
@@ -3,11 +3,11 @@ use std::fmt::Debug;
 use crate::error::Result;
 use crate::service_type::ServiceType;
 
-pub trait Authenticator: Debug + Send + Sync {
+#[derive(Debug, Clone, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum Authenticator {
+    PasswordAuthenticator(PasswordAuthenticator),
     // TODO: get_client_certificate needs some thought about how to expose the certificate
-    // fn get_client_certificate(service: ServiceType, host_port: String) ->
-    fn get_credentials(&self, service_type: ServiceType, host_port: String)
-        -> Result<UserPassPair>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -22,8 +22,8 @@ pub struct PasswordAuthenticator {
     pub password: String,
 }
 
-impl Authenticator for PasswordAuthenticator {
-    fn get_credentials(
+impl PasswordAuthenticator {
+    pub fn get_credentials(
         &self,
         _service_type: ServiceType,
         _host_port: String,
@@ -32,5 +32,11 @@ impl Authenticator for PasswordAuthenticator {
             username: self.username.clone(),
             password: self.password.clone(),
         })
+    }
+}
+
+impl From<PasswordAuthenticator> for Authenticator {
+    fn from(value: PasswordAuthenticator) -> Self {
+        Authenticator::PasswordAuthenticator(value)
     }
 }

--- a/sdk/couchbase-core/src/configwatcher.rs
+++ b/sdk/couchbase-core/src/configwatcher.rs
@@ -224,10 +224,13 @@ mod tests {
             root_certs: None,
             accept_all_certs: None,
             client_name: "myclient".to_string(),
-            authenticator: Some(Arc::new(PasswordAuthenticator {
-                username: "Administrator".to_string(),
-                password: "password".to_string(),
-            })),
+            authenticator: Some(Arc::new(
+                PasswordAuthenticator {
+                    username: "Administrator".to_string(),
+                    password: "password".to_string(),
+                }
+                .into(),
+            )),
             selected_bucket: Some("default".to_string()),
             disable_default_features: false,
             disable_error_map: false,

--- a/sdk/couchbase-core/src/crudcomponent.rs
+++ b/sdk/couchbase-core/src/crudcomponent.rs
@@ -193,10 +193,13 @@ mod tests {
             root_certs: None,
             accept_all_certs: None,
             client_name: "myclient".to_string(),
-            authenticator: Some(Arc::new(PasswordAuthenticator {
-                username: "Administrator".to_string(),
-                password: "password".to_string(),
-            })),
+            authenticator: Some(Arc::new(
+                PasswordAuthenticator {
+                    username: "Administrator".to_string(),
+                    password: "password".to_string(),
+                }
+                .into(),
+            )),
             selected_bucket: Some("default".to_string()),
             disable_default_features: false,
             disable_error_map: false,

--- a/sdk/couchbase-core/src/kvclientpool.rs
+++ b/sdk/couchbase-core/src/kvclientpool.rs
@@ -357,10 +357,13 @@ mod tests {
             root_certs: None,
             accept_all_certs: None,
             client_name: "myclient".to_string(),
-            authenticator: Some(Arc::new(PasswordAuthenticator {
-                username: "Administrator".to_string(),
-                password: "password".to_string(),
-            })),
+            authenticator: Some(Arc::new(
+                PasswordAuthenticator {
+                    username: "Administrator".to_string(),
+                    password: "password".to_string(),
+                }
+                .into(),
+            )),
             selected_bucket: Some("default".to_string()),
             disable_default_features: false,
             disable_error_map: false,
@@ -449,10 +452,13 @@ mod tests {
             root_certs: None,
             accept_all_certs: None,
             client_name: "myclient".to_string(),
-            authenticator: Some(Arc::new(PasswordAuthenticator {
-                username: "Administrator".to_string(),
-                password: "password".to_string(),
-            })),
+            authenticator: Some(Arc::new(
+                PasswordAuthenticator {
+                    username: "Administrator".to_string(),
+                    password: "password".to_string(),
+                }
+                .into(),
+            )),
             selected_bucket: None,
             disable_default_features: false,
             disable_error_map: false,
@@ -481,10 +487,13 @@ mod tests {
             root_certs: None,
             accept_all_certs: None,
             client_name: "myclient".to_string(),
-            authenticator: Some(Arc::new(PasswordAuthenticator {
-                username: "Administrator".to_string(),
-                password: "password".to_string(),
-            })),
+            authenticator: Some(Arc::new(
+                PasswordAuthenticator {
+                    username: "Administrator".to_string(),
+                    password: "password".to_string(),
+                }
+                .into(),
+            )),
             selected_bucket: Some("default".to_string()),
             disable_default_features: false,
             disable_error_map: false,


### PR DESCRIPTION
Motivation
----------
Authenticator being a trait makes it more difficult to work with than if it was an enum. It is intended to be a public facing interface but with private-only implementations. As we know all of the implementations we can just use an enum.

Changes
--------
Change authenticator to be an enum.