### PR TITLE
Update memdx channel usage to use callbacks where possible

### DIFF
--- a/sdk/couchbase-core/Cargo.toml
+++ b/sdk/couchbase-core/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = "0.1.80"
 tokio-io = { version = "0.2.0-alpha.6", features = ["util"] }
 crc32fast = "1.4.2"
 serde_json = "1.0.120"
+arc-swap = "1.7"
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/sdk/couchbase-core/src/crudcomponent.rs
+++ b/sdk/couchbase-core/src/crudcomponent.rs
@@ -138,7 +138,6 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use tokio::sync::mpsc::unbounded_channel;
     use tokio::time::Instant;
 
     use crate::authenticator::PasswordAuthenticator;
@@ -151,7 +150,6 @@ mod tests {
     };
     use crate::kvclientpool::NaiveKvClientPool;
     use crate::memdx::client::Client;
-    use crate::memdx::packet::ResponsePacket;
     use crate::vbucketmap::VbucketMap;
     use crate::vbucketrouter::{
         NotMyVbucketConfigHandler, StdVbucketRouter, VbucketRouterOptions, VbucketRoutingInfo,
@@ -170,21 +168,6 @@ mod tests {
         let _ = env_logger::try_init();
 
         let instant = Instant::now().add(Duration::new(7, 0));
-
-        let (orphan_tx, mut orphan_rx) = unbounded_channel::<ResponsePacket>();
-
-        tokio::spawn(async move {
-            loop {
-                match orphan_rx.recv().await {
-                    Some(resp) => {
-                        dbg!("unexpected orphan", resp);
-                    }
-                    None => {
-                        return;
-                    }
-                }
-            }
-        });
 
         let client_config = KvClientConfig {
             address: "192.168.107.128:11210"
@@ -220,7 +203,7 @@ mod tests {
                 KvClientManagerOptions {
                     connect_timeout: Default::default(),
                     connect_throttle_period: Default::default(),
-                    orphan_handler: Arc::new(orphan_tx),
+                    orphan_handler: Arc::new(|_| {}),
                 },
             )
             .await

--- a/sdk/couchbase-core/src/kvclientmanager.rs
+++ b/sdk/couchbase-core/src/kvclientmanager.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::Mutex;
 
 use crate::error::ErrorKind;
@@ -11,7 +10,7 @@ use crate::error::Result;
 use crate::kvclient::{KvClient, KvClientConfig};
 use crate::kvclient_ops::KvClientOps;
 use crate::kvclientpool::{KvClientPool, KvClientPoolConfig, KvClientPoolOptions};
-use crate::memdx::packet::ResponsePacket;
+use crate::memdx::dispatcher::OrphanResponseHandler;
 
 pub(crate) type KvClientManagerClientType<M> =
     <<M as KvClientManager>::Pool as KvClientPool>::Client;
@@ -46,11 +45,11 @@ pub(crate) struct KvClientManagerConfig {
     pub clients: HashMap<String, KvClientConfig>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct KvClientManagerOptions {
     pub connect_timeout: Duration,
     pub connect_throttle_period: Duration,
-    pub orphan_handler: Arc<UnboundedSender<ResponsePacket>>,
+    pub orphan_handler: OrphanResponseHandler,
 }
 
 #[derive(Debug)]

--- a/sdk/couchbase-core/src/lib.rs
+++ b/sdk/couchbase-core/src/lib.rs
@@ -1,4 +1,7 @@
 #![feature(async_closure)]
+// #![feature(unboxed_closures)]
+#![feature(async_fn_traits)]
+#![feature(unboxed_closures)]
 
 pub mod authenticator;
 pub mod cbconfig;

--- a/sdk/couchbase-core/src/memdx/dispatcher.rs
+++ b/sdk/couchbase-core/src/memdx/dispatcher.rs
@@ -1,18 +1,19 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::oneshot;
+use futures::future::BoxFuture;
 
 use crate::memdx::connection::Connection;
 use crate::memdx::error::Result;
 use crate::memdx::packet::{RequestPacket, ResponsePacket};
 use crate::memdx::pendingop::ClientPendingOp;
 
-#[derive(Debug)]
+pub type OrphanResponseHandler = Arc<dyn Fn(ResponsePacket) + Send + Sync>;
+pub type OnConnectionCloseHandler = Arc<dyn Fn() -> BoxFuture<'static, ()> + Send + Sync>;
+
 pub struct DispatcherOptions {
-    pub orphan_handler: Arc<UnboundedSender<ResponsePacket>>,
-    pub on_connection_close_handler: Option<oneshot::Sender<Result<()>>>,
+    pub orphan_handler: OrphanResponseHandler,
+    pub on_connection_close_handler: OnConnectionCloseHandler,
 }
 
 #[async_trait]


### PR DESCRIPTION
Motivation
-----------
Using channels for things like orphan handler requires us to spin up new tasks, the flow is also a bit easier to follow with callbacks.

Changes
-------
Update orphan handling and connection close handling to use callbacks. Rewrite kvclientpool to make this possible.