### PR TITLE
RSCBC-32: Add allocation counting test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .idea/
 Cargo.lock
+dhat-heap.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["sdk/couchbase-core", "sdk/protostellar"]
 resolver = "2"
+
+[profile.test]
+debug = 1

--- a/sdk/couchbase-core/Cargo.toml
+++ b/sdk/couchbase-core/Cargo.toml
@@ -31,10 +31,15 @@ snap = "1.1"
 reqwest = { version = "0.12.5", features = ["json", "stream", "rustls-tls"], default-features = false }
 http = "1.1.0"
 
+dhat = { version = "0.3.3", optional = true }
+
 [dev-dependencies]
 env_logger = "0.11"
 envconfig = "0.10"
 chrono = "0.4.38"
+
+[features]
+dhat-heap = ["dhat"]
 
 [lints.rust]
 # This is temporary whilst we build out the root modules.

--- a/sdk/couchbase-core/src/kvclientpool.rs
+++ b/sdk/couchbase-core/src/kvclientpool.rs
@@ -160,7 +160,8 @@ where
         if num_wanted_clients > num_active_clients {
             let mut num_needed_clients = num_wanted_clients - num_active_clients;
             while num_needed_clients > 0 {
-                if let Some(client) = self.spawner.lock().await.start_new_client::<K>().await {
+                let mut guard = self.spawner.lock().await;
+                if let Some(client) = guard.start_new_client::<K>().await {
                     if self.closed.load(Ordering::SeqCst) {
                         client.close().await.unwrap_or_default();
                     }

--- a/sdk/couchbase-core/src/retryfailfast.rs
+++ b/sdk/couchbase-core/src/retryfailfast.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use crate::retry::{RetryAction, RetryInfo, RetryReason, RetryStrategy};
 
 #[derive(Debug, Default)]
-pub(crate) struct FailFastRetryStrategy {}
+pub struct FailFastRetryStrategy {}
 
 #[async_trait]
 impl RetryStrategy for FailFastRetryStrategy {

--- a/sdk/couchbase-core/tests/agent_ops.rs
+++ b/sdk/couchbase-core/tests/agent_ops.rs
@@ -110,9 +110,9 @@ async fn test_kv_without_a_bucket() {
 #[cfg(feature = "dhat-heap")]
 #[tokio::test]
 async fn upsert_allocations() {
-    let profiler = dhat::Profiler::builder().build();
-
     setup_tests();
+
+    let profiler = dhat::Profiler::builder().build();
 
     let agent_opts = create_default_options();
 


### PR DESCRIPTION
Motivation
----------
In order to optimize allocations we first need a way to track them. This change adds capabilities to do so, and adds a simple illustrative test which prints out allocations rather than enforcing how many can occurt before failing.

Changes
--------
Add a dependency on dhat.
Add a feature flag to enable it.
Add a simple test using dhat for heap profiling.