### PR TITLE
Pin nightly version and ignore clippy for autogenerated files

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-08-28"

--- a/sdk/protostellar/src/lib.rs
+++ b/sdk/protostellar/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::all)]
+
 pub mod couchbase {
     pub mod admin {
         pub mod analytics {


### PR DESCRIPTION
Motivation
-----------
A recent compiler change in nightly has caused compilation to fail. This appears to be a bug in the compiler so for now we need to pin which nightly version we use.