### PR TITLE
RSCBC-578: Move connstr to its own crate

### DIFF
--- a/.github/workflows/sort.yml
+++ b/.github/workflows/sort.yml
@@ -17,4 +17,4 @@ jobs:
           git: https://github.com/devinr528/cargo-sort
           tag: v1.0.9
       - name: Run cargo sort
-        run: cargo sort -c -g sdk/couchbase-core/Cargo.toml sdk/protostellar/Cargo.toml
+        run: cargo sort -c -g -w

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["sdk/couchbase-core", "sdk/protostellar", "sdk/couchbase"]
+members = ["sdk/couchbase", "sdk/couchbase-connstr", "sdk/couchbase-core", "sdk/protostellar"]
 resolver = "2"

--- a/sdk/couchbase-connstr/Cargo.toml
+++ b/sdk/couchbase-connstr/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "couchbase_connstr"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+form_urlencoded = "1.2.1"
+hickory-resolver = { version = "0.24.1", features = ["dns-over-rustls"], default-features = false }
+regex = "1.11.0"
+thiserror = "1.0"
+url = "2.5.2"

--- a/sdk/couchbase-connstr/src/error.rs
+++ b/sdk/couchbase-connstr/src/error.rs
@@ -1,0 +1,68 @@
+use std::fmt::{Display, Formatter};
+use std::{fmt, io};
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Clone, Error)]
+pub struct Error {
+    pub(crate) kind: ErrorKind,
+}
+
+impl Error {
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    #[error("failed to parse: {0}")]
+    Parse(String),
+    #[error("invalid argument: {0}")]
+    InvalidArgument(&'static str),
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+    #[error("resolve error: {0}")]
+    Resolve(#[from] hickory_resolver::error::ResolveError),
+}
+
+impl Clone for ErrorKind {
+    fn clone(&self) -> Self {
+        match self {
+            ErrorKind::Parse(s) => ErrorKind::Parse(s.clone()),
+            ErrorKind::InvalidArgument(s) => ErrorKind::InvalidArgument(s),
+            ErrorKind::Io(e) => Self::from(io::Error::from(e.kind())),
+            ErrorKind::Resolve(e) => Self::from(e.clone()),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.kind, f)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self {
+            kind: ErrorKind::Io(e),
+        }
+    }
+}
+
+impl From<hickory_resolver::error::ResolveError> for Error {
+    fn from(e: hickory_resolver::error::ResolveError) -> Self {
+        Self {
+            kind: ErrorKind::Resolve(e),
+        }
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self { kind }
+    }
+}

--- a/sdk/couchbase/Cargo.toml
+++ b/sdk/couchbase/Cargo.toml
@@ -8,7 +8,6 @@ async-trait = "0.1.83"
 bytes = "1.5.0"
 chrono = "0.4.38"
 futures = "0.3.30"
-hickory-resolver = { version = "0.24.1", features = ["dns-over-rustls"], default-features = false }
 lazy_static = "1.5.0"
 log = "0.4.22"
 regex = "1.11.0"
@@ -20,6 +19,7 @@ url = "2.5.2"
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", features = ["v4"] }
 
+couchbase_connstr = { path = "../couchbase-connstr" }
 couchbase_core = { path = "../couchbase-core" }
 
 [dev-dependencies]

--- a/sdk/couchbase/src/clients/cluster_client.rs
+++ b/sdk/couchbase/src/clients/cluster_client.rs
@@ -2,9 +2,9 @@ use crate::clients::bucket_client::{
     BucketClient, BucketClientBackend, Couchbase2BucketClient, CouchbaseBucketClient,
 };
 use crate::clients::query_client::{CouchbaseQueryClient, QueryClient, QueryClientBackend};
-use crate::connstr::{parse, resolve, Address, SrvRecord};
 use crate::error;
 use crate::options::cluster_options::ClusterOptions;
+use couchbase_connstr::{parse, resolve, Address, SrvRecord};
 use couchbase_core::ondemand_agentmanager::{OnDemandAgentManager, OnDemandAgentManagerOptions};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/sdk/couchbase/src/error.rs
+++ b/sdk/couchbase/src/error.rs
@@ -20,3 +20,11 @@ impl From<serde_json::Error> for Error {
         }
     }
 }
+
+impl From<couchbase_connstr::error::Error> for Error {
+    fn from(value: couchbase_connstr::error::Error) -> Self {
+        Self {
+            msg: value.to_string(),
+        }
+    }
+}

--- a/sdk/couchbase/src/lib.rs
+++ b/sdk/couchbase/src/lib.rs
@@ -5,7 +5,6 @@ mod clients;
 pub mod cluster;
 pub mod collection;
 pub mod collection_crud;
-pub mod connstr;
 pub mod error;
 mod mutation_state;
 pub mod options;


### PR DESCRIPTION
Motivation
-----------
Moving the connstr module to its own crate will improve the reusability and allow us to easily use it in testing the core.