### PR TITLE
RSCBC-61: Update ext node configs to have optional hostname

### DIFF
--- a/sdk/couchbase-core/src/cbconfig/mod.rs
+++ b/sdk/couchbase-core/src/cbconfig/mod.rs
@@ -66,7 +66,7 @@ pub struct TerseExtNodeAltAddresses {
     #[serde(alias = "ports")]
     pub ports: TerseExtNodePorts,
     #[serde(alias = "hostname")]
-    pub hostname: String,
+    pub hostname: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -94,7 +94,7 @@ pub struct TerseNodeExtConfig {
     #[serde(alias = "thisNode")]
     pub this_node: Option<bool>,
     #[serde(alias = "hostname")]
-    pub hostname: String,
+    pub hostname: Option<String>,
     #[serde(alias = "alternateAddresses", default)]
     pub alternate_addresses: HashMap<String, TerseExtNodeAltAddresses>,
 }

--- a/sdk/couchbase-core/src/configparser.rs
+++ b/sdk/couchbase-core/src/configparser.rs
@@ -88,16 +88,16 @@ impl ConfigParser {
         })
     }
 
-    fn parse_config_hostname(hostname: &str, source_hostname: &str) -> String {
-        if hostname.is_empty() {
-            return source_hostname.to_string();
-        }
+    fn parse_config_hostname(hostname: &Option<String>, source_hostname: &str) -> String {
+        if let Some(hostname) = hostname {
+            if hostname.contains(':') {
+                return format!("[{}]", hostname);
+            }
 
-        if hostname.contains(':') {
-            return format!("[{}]", hostname);
+            hostname.to_string()
+        } else {
+            source_hostname.to_string()
         }
-
-        hostname.to_string()
     }
 
     fn parse_config_hosts_into(


### PR DESCRIPTION
Motivation
----------
Hostname in the ext node configs is not always populated in a single node cluster.