### PR TITLE
Rework json stream implementation

### DIFF
--- a/sdk/couchbase-core/src/searchx/search.rs
+++ b/sdk/couchbase-core/src/searchx/search.rs
@@ -7,7 +7,6 @@ use crate::searchx::query_options::QueryOptions;
 use crate::searchx::search_respreader::SearchRespReader;
 use bytes::Bytes;
 use http::{Method, StatusCode};
-use std::backtrace::Backtrace;
 use std::collections::HashMap;
 use std::sync::Arc;
 use typed_builder::TypedBuilder;
@@ -84,7 +83,6 @@ impl<C: Client> Search<C> {
                 }),
                 endpoint: self.endpoint.clone(),
                 status_code: None,
-                backtrace: Backtrace::capture(),
                 source: None,
             });
         }
@@ -113,8 +111,7 @@ impl<C: Client> Search<C> {
             }),
             endpoint: self.endpoint.clone(),
             status_code: None,
-            backtrace: Backtrace::capture(),
-            source: Some(Box::new(e)),
+            source: Some(Arc::new(e)),
         })?;
 
         let res = self
@@ -155,8 +152,7 @@ impl<C: Client> Search<C> {
             }),
             endpoint: self.endpoint.clone(),
             status_code: None,
-            backtrace: Backtrace::capture(),
-            source: Some(Box::new(e)),
+            source: Some(Arc::new(e)),
         })?;
 
         let mut headers = HashMap::new();
@@ -234,8 +230,7 @@ pub(crate) async fn decode_response_error(response: Response, endpoint: String) 
                 }),
                 endpoint,
                 status_code: Some(status),
-                backtrace: Backtrace::capture(),
-                source: Some(Box::new(e)),
+                source: Some(Arc::new(e)),
             }
         }
     };
@@ -249,8 +244,7 @@ pub(crate) async fn decode_response_error(response: Response, endpoint: String) 
                 }),
                 endpoint,
                 status_code: Some(status),
-                backtrace: Backtrace::capture(),
-                source: Some(Box::new(e)),
+                source: Some(Arc::new(e)),
             }
         }
     };

--- a/sdk/couchbase-core/src/searchx/search_json.rs
+++ b/sdk/couchbase-core/src/searchx/search_json.rs
@@ -6,8 +6,8 @@ use crate::searchx::search_result::{
 use chrono::DateTime;
 use serde::Deserialize;
 use serde_json::value::RawValue;
-use std::backtrace::Backtrace;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct SearchMetadataStatus {
@@ -80,8 +80,7 @@ impl TryFrom<DateFacet> for DateRangeFacetResult {
                 kind: Box::new(error::ErrorKind::Json {
                     msg: format!("failed to parse date: {}", &e),
                 }),
-                backtrace: Backtrace::capture(),
-                source: Some(Box::new(e)),
+                source: Some(Arc::new(e)),
                 endpoint: "".to_string(),
                 status_code: None,
             })?,
@@ -89,8 +88,7 @@ impl TryFrom<DateFacet> for DateRangeFacetResult {
                 kind: Box::new(error::ErrorKind::Json {
                     msg: format!("failed to parse date: {}", &e),
                 }),
-                backtrace: Backtrace::capture(),
-                source: Some(Box::new(e)),
+                source: Some(Arc::new(e)),
                 endpoint: "".to_string(),
                 status_code: None,
             })?,


### PR DESCRIPTION
Motivation
----------
We currently implement stream so that it streams all of the rows and then returns None, a user must then cfall read_epilog to finish reading items off the stream - e.g. metadata. This is actually quite challenging to do as a consumer of the json stream, it'd be better if the epilog was parsed as a part of the stream.