### PR TITLE
RSCBC-62: Refactored hostname handling when parsing configs

### DIFF
--- a/sdk/couchbase-connstr/Cargo.toml
+++ b/sdk/couchbase-connstr/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [dependencies]
 form_urlencoded = "1.2.1"
 hickory-resolver = { version = "0.24.1", features = ["dns-over-rustls"], default-features = false }
+log = "0.4.22"
 regex = "1.11.0"
 thiserror = "1.0"
 url = "2.5.2"
+
+[dev-dependencies]
+tokio = { version = "1.40", features = ["rt", "net", "macros"] }

--- a/sdk/couchbase-core/src/agent_ops.rs
+++ b/sdk/couchbase-core/src/agent_ops.rs
@@ -1,6 +1,14 @@
 use crate::agent::Agent;
-use crate::crudoptions::{AddOptions, AppendOptions, DecrementOptions, DeleteOptions, GetAndLockOptions, GetAndTouchOptions, GetMetaOptions, GetOptions, IncrementOptions, LookupInOptions, MutateInOptions, PrependOptions, ReplaceOptions, TouchOptions, UnlockOptions, UpsertOptions};
-use crate::crudresults::{AddResult, AppendResult, DecrementResult, DeleteResult, GetAndLockResult, GetAndTouchResult, GetMetaResult, GetResult, IncrementResult, LookupInResult, MutateInResult, PrependResult, ReplaceResult, TouchResult, UnlockResult, UpsertResult};
+use crate::crudoptions::{
+    AddOptions, AppendOptions, DecrementOptions, DeleteOptions, GetAndLockOptions,
+    GetAndTouchOptions, GetMetaOptions, GetOptions, IncrementOptions, LookupInOptions,
+    MutateInOptions, PrependOptions, ReplaceOptions, TouchOptions, UnlockOptions, UpsertOptions,
+};
+use crate::crudresults::{
+    AddResult, AppendResult, DecrementResult, DeleteResult, GetAndLockResult, GetAndTouchResult,
+    GetMetaResult, GetResult, IncrementResult, LookupInResult, MutateInResult, PrependResult,
+    ReplaceResult, TouchResult, UnlockResult, UpsertResult,
+};
 use crate::error::Result;
 use crate::querycomponent::QueryResultStream;
 use crate::queryoptions::QueryOptions;

--- a/sdk/couchbase-core/src/cbconfig/mod.rs
+++ b/sdk/couchbase-core/src/cbconfig/mod.rs
@@ -1,3 +1,5 @@
+pub mod parse;
+
 use std::collections::HashMap;
 
 use serde::Deserialize;

--- a/sdk/couchbase-core/src/cbconfig/parse.rs
+++ b/sdk/couchbase-core/src/cbconfig/parse.rs
@@ -1,0 +1,15 @@
+use crate::cbconfig::TerseConfig;
+use crate::error;
+use crate::error::ErrorKind;
+
+pub fn parse_terse_config(config: &[u8], source_hostname: &str) -> error::Result<TerseConfig> {
+    let mut config = match std::str::from_utf8(config) {
+        Ok(v) => v.to_string(),
+        Err(e) => {
+            return Err(ErrorKind::Generic { msg: e.to_string() }.into());
+        }
+    };
+    config = config.replace("$HOST", source_hostname);
+    let config_out: TerseConfig = serde_json::from_str(&config)?;
+    Ok(config_out)
+}

--- a/sdk/couchbase-core/src/kvclient_ops.rs
+++ b/sdk/couchbase-core/src/kvclient_ops.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use crate::error::Error;
 use crate::error::Result;
 use crate::kvclient::{KvClient, StdKvClient};
+use crate::memdx;
 use crate::memdx::dispatcher::Dispatcher;
 use crate::memdx::hello_feature::HelloFeature;
 use crate::memdx::op_bootstrap::{BootstrapOptions, OpBootstrap, OpBootstrapEncoder};
@@ -10,8 +11,19 @@ use crate::memdx::ops_core::OpsCore;
 use crate::memdx::ops_crud::OpsCrud;
 use crate::memdx::ops_util::OpsUtil;
 use crate::memdx::pendingop::PendingOp;
-use crate::memdx::request::{AddRequest, AppendRequest, DecrementRequest, DeleteRequest, GetAndLockRequest, GetAndTouchRequest, GetClusterConfigRequest, GetCollectionIdRequest, GetMetaRequest, GetRequest, IncrementRequest, LookupInRequest, MutateInRequest, PrependRequest, ReplaceRequest, SelectBucketRequest, SetRequest, TouchRequest, UnlockRequest};
-use crate::memdx::response::{AddResponse, AppendResponse, BootstrapResult, DecrementResponse, DeleteResponse, GetAndLockResponse, GetAndTouchResponse, GetClusterConfigResponse, GetCollectionIdResponse, GetMetaResponse, GetResponse, IncrementResponse, LookupInResponse, MutateInResponse, PrependResponse, ReplaceResponse, SelectBucketResponse, SetResponse, TouchResponse, UnlockResponse};
+use crate::memdx::request::{
+    AddRequest, AppendRequest, DecrementRequest, DeleteRequest, GetAndLockRequest,
+    GetAndTouchRequest, GetClusterConfigRequest, GetCollectionIdRequest, GetMetaRequest,
+    GetRequest, IncrementRequest, LookupInRequest, MutateInRequest, PrependRequest, ReplaceRequest,
+    SelectBucketRequest, SetRequest, TouchRequest, UnlockRequest,
+};
+use crate::memdx::response::{
+    AddResponse, AppendResponse, BootstrapResult, DecrementResponse, DeleteResponse,
+    GetAndLockResponse, GetAndTouchResponse, GetClusterConfigResponse, GetCollectionIdResponse,
+    GetMetaResponse, GetResponse, IncrementResponse, LookupInResponse, MutateInResponse,
+    PrependResponse, ReplaceResponse, SelectBucketResponse, SetResponse, TouchResponse,
+    UnlockResponse,
+};
 
 pub(crate) trait KvClientOps: Sized + Send + Sync {
     fn set(&self, req: SetRequest) -> impl Future<Output = Result<SetResponse>> + Send;
@@ -66,114 +78,130 @@ where
     D: Dispatcher,
 {
     async fn set<'a>(&self, req: SetRequest<'a>) -> Result<SetResponse> {
-        let mut op = self.ops_crud().set(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().set(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn get<'a>(&self, req: GetRequest<'a>) -> Result<GetResponse> {
-        let mut op = self.ops_crud().get(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().get(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn get_meta<'a>(&self, req: GetMetaRequest<'a>) -> Result<GetMetaResponse> {
-        let mut op = self.ops_crud().get_meta(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().get_meta(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn delete<'a>(&self, req: DeleteRequest<'a>) -> Result<DeleteResponse> {
-        let mut op = self.ops_crud().delete(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().delete(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn get_and_lock<'a>(&self, req: GetAndLockRequest<'a>) -> Result<GetAndLockResponse> {
-        let mut op = self.ops_crud().get_and_lock(self.client(), req).await?;
+        let mut op = self
+            .handle_dispatch_side_result(self.ops_crud().get_and_lock(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn get_and_touch<'a>(&self, req: GetAndTouchRequest<'a>) -> Result<GetAndTouchResponse> {
-        let mut op = self.ops_crud().get_and_touch(self.client(), req).await?;
+        let mut op = self
+            .handle_dispatch_side_result(self.ops_crud().get_and_touch(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn unlock<'a>(&self, req: UnlockRequest<'a>) -> Result<UnlockResponse> {
-        let mut op = self.ops_crud().unlock(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().unlock(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn touch<'a>(&self, req: TouchRequest<'a>) -> Result<TouchResponse> {
-        let mut op = self.ops_crud().touch(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().touch(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn add<'a>(&self, req: AddRequest<'a>) -> Result<AddResponse> {
-        let mut op = self.ops_crud().add(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().add(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn replace<'a>(&self, req: ReplaceRequest<'a>) -> Result<ReplaceResponse> {
-        let mut op = self.ops_crud().replace(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().replace(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn append<'a>(&self, req: AppendRequest<'a>) -> Result<AppendResponse> {
-        let mut op = self.ops_crud().append(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().append(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn prepend<'a>(&self, req: PrependRequest<'a>) -> Result<PrependResponse> {
-        let mut op = self.ops_crud().prepend(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().prepend(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn increment<'a>(&self, req: IncrementRequest<'a>) -> Result<IncrementResponse> {
-        let mut op = self.ops_crud().increment(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().increment(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn decrement<'a>(&self, req: DecrementRequest<'a>) -> Result<DecrementResponse> {
-        let mut op = self.ops_crud().decrement(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().decrement(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn lookup_in<'a>(&self, req: LookupInRequest<'a>) -> Result<LookupInResponse> {
-        let mut op = self.ops_crud().lookup_in(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().lookup_in(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
     async fn mutate_in<'a>(&self, req: MutateInRequest<'a>) -> Result<MutateInResponse> {
-        let mut op = self.ops_crud().mutate_in(self.client(), req).await?;
+        let mut op =
+            self.handle_dispatch_side_result(self.ops_crud().mutate_in(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
@@ -181,9 +209,10 @@ where
         &self,
         req: GetClusterConfigRequest,
     ) -> Result<GetClusterConfigResponse> {
-        let mut op = OpsCore {}.get_cluster_config(self.client(), req).await?;
+        let mut op = self
+            .handle_dispatch_side_result(OpsCore {}.get_cluster_config(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 
@@ -191,9 +220,10 @@ where
         &self,
         req: GetCollectionIdRequest,
     ) -> Result<GetCollectionIdResponse> {
-        let mut op = OpsUtil {}.get_collection_id(self.client(), req).await?;
+        let mut op = self
+            .handle_dispatch_side_result(OpsUtil {}.get_collection_id(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 }
@@ -202,19 +232,45 @@ impl<D> StdKvClient<D>
 where
     D: Dispatcher,
 {
+    fn handle_dispatch_side_result<T>(&self, result: memdx::error::Result<T>) -> Result<T> {
+        match result {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                let (dispatched_to, dispatched_from) = if e.is_dispatch_error() {
+                    (Some(self.remote_addr()), Some(self.local_addr()))
+                } else {
+                    (None, None)
+                };
+
+                Err(Error::new_memdx_error(e, dispatched_to, dispatched_from))
+            }
+        }
+    }
+
+    fn handle_response_side_result<T>(&self, result: memdx::error::Result<T>) -> Result<T> {
+        match result {
+            Ok(v) => Ok(v),
+            Err(e) => Err(Error::new_memdx_error(
+                e,
+                Some(self.remote_addr()),
+                Some(self.local_addr()),
+            )),
+        }
+    }
+
     pub async fn bootstrap(&self, opts: BootstrapOptions) -> Result<BootstrapResult> {
         OpBootstrap::bootstrap(OpsCore {}, self.client(), opts)
             .await
-            .map_err(Error::from)
+            .map_err(|e| {
+                Error::new_memdx_error(e, Some(self.remote_addr()), Some(self.local_addr()))
+            })
     }
 
     pub async fn select_bucket(&self, req: SelectBucketRequest) -> Result<SelectBucketResponse> {
-        let mut op = OpsCore {}
-            .select_bucket(self.client(), req)
-            .await
-            .map_err(Error::from)?;
+        let mut op =
+            self.handle_dispatch_side_result(OpsCore {}.select_bucket(self.client(), req).await)?;
 
-        let res = op.recv().await?;
+        let res = self.handle_response_side_result(op.recv().await)?;
         Ok(res)
     }
 

--- a/sdk/couchbase-core/src/memdx/client_response.rs
+++ b/sdk/couchbase-core/src/memdx/client_response.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use crate::memdx::client::ResponseContext;
 use crate::memdx::packet::ResponsePacket;
 use tokio::sync::oneshot;
@@ -10,24 +8,17 @@ pub struct ClientResponse {
     has_more_sender: oneshot::Sender<bool>,
 
     response_context: ResponseContext,
-
-    local_addr: Option<SocketAddr>,
-    peer_addr: Option<SocketAddr>,
 }
 
 impl ClientResponse {
     pub fn new(
         packet: ResponsePacket,
         has_more_sender: oneshot::Sender<bool>,
-        local_addr: Option<SocketAddr>,
-        peer_addr: Option<SocketAddr>,
         response_context: ResponseContext,
     ) -> Self {
         Self {
             packet,
             has_more_sender,
-            local_addr,
-            peer_addr,
             response_context,
         }
     }
@@ -41,16 +32,6 @@ impl ClientResponse {
             Ok(_) => {}
             Err(_e) => {}
         };
-    }
-
-    // local_addr is the address corresponding to the server, i.e. local to the responder.
-    pub fn local_addr(&self) -> &Option<SocketAddr> {
-        &self.local_addr
-    }
-
-    // peer_addr is the address corresponding to the client, i.e. local to the recipient.
-    pub fn peer_addr(&self) -> &Option<SocketAddr> {
-        &self.peer_addr
     }
 
     pub fn response_context(&self) -> &ResponseContext {

--- a/sdk/couchbase-core/src/memdx/ops_core.rs
+++ b/sdk/couchbase-core/src/memdx/ops_core.rs
@@ -1,11 +1,10 @@
 use std::io::Write;
-use std::net::SocketAddr;
 
 use byteorder::{BigEndian, WriteBytesExt};
 
 use crate::memdx::dispatcher::Dispatcher;
-use crate::memdx::error::{ServerError, ServerErrorKind};
 use crate::memdx::error::Result;
+use crate::memdx::error::{ServerError, ServerErrorKind};
 use crate::memdx::magic::Magic;
 use crate::memdx::op_auth_saslauto::OpSASLAutoEncoder;
 use crate::memdx::op_auth_saslbyname::OpSASLAuthByNameEncoder;
@@ -31,10 +30,8 @@ impl OpsCore {
     pub(crate) fn decode_error_context(
         resp: &ResponsePacket,
         kind: ServerErrorKind,
-        dispatched_to: &Option<SocketAddr>,
-        dispatched_from: &Option<SocketAddr>,
     ) -> ServerError {
-        let mut base_cause = ServerError::new(kind, resp, dispatched_to, dispatched_from);
+        let mut base_cause = ServerError::new(kind, resp);
 
         if let Some(value) = &resp.value {
             if resp.status == Status::NotMyVbucket {
@@ -48,11 +45,7 @@ impl OpsCore {
         base_cause
     }
 
-    pub(crate) fn decode_error(
-        resp: &ResponsePacket,
-        dispatched_to: &Option<SocketAddr>,
-        dispatched_from: &Option<SocketAddr>,
-    ) -> ServerError {
+    pub(crate) fn decode_error(resp: &ResponsePacket) -> ServerError {
         let status = resp.status;
         let base_error_kind = if status == Status::NotMyVbucket {
             ServerErrorKind::NotMyVbucket
@@ -64,7 +57,7 @@ impl OpsCore {
             ServerErrorKind::UnknownStatus { status }
         };
 
-        Self::decode_error_context(resp, base_error_kind, dispatched_to, dispatched_from)
+        Self::decode_error_context(resp, base_error_kind)
     }
 }
 

--- a/sdk/couchbase-core/src/memdx/ops_crud.rs
+++ b/sdk/couchbase-core/src/memdx/ops_crud.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::time::Duration;
 use byteorder::{BigEndian, WriteBytesExt, ByteOrder};
 use bytes::{BufMut, BytesMut};
@@ -1005,11 +1004,7 @@ impl OpsCrud {
         Ok(magic)
     }
 
-    pub(crate) fn decode_common_status(
-        resp: &ResponsePacket,
-        dispatched_to: &Option<SocketAddr>,
-        dispatched_from: &Option<SocketAddr>,
-    ) -> std::result::Result<(), Error> {
+    pub(crate) fn decode_common_status(resp: &ResponsePacket) -> std::result::Result<(), Error> {
         let kind = match resp.status {
             Status::CollectionUnknown => ServerErrorKind::UnknownCollectionID,
             Status::AccessError => ServerErrorKind::Access,
@@ -1019,19 +1014,15 @@ impl OpsCrud {
             }
         };
 
-        Err(ServerError::new(kind, resp, dispatched_to, dispatched_from).into())
+        Err(ServerError::new(kind, resp).into())
     }
 
-    pub(crate) fn decode_common_error(
-        resp: &ResponsePacket,
-        dispatched_to: &Option<SocketAddr>,
-        dispatched_from: &Option<SocketAddr>,
-    ) -> Error {
-        if let Err(e) = Self::decode_common_status(resp, dispatched_to, dispatched_from) {
+    pub(crate) fn decode_common_error(resp: &ResponsePacket) -> Error {
+        if let Err(e) = Self::decode_common_status(resp) {
             return e;
         };
 
-        OpsCore::decode_error(resp, dispatched_to, dispatched_from).into()
+        OpsCore::decode_error(resp).into()
     }
 }
 

--- a/sdk/couchbase-core/src/retry.rs
+++ b/sdk/couchbase-core/src/retry.rs
@@ -163,11 +163,11 @@ where
 
 pub(crate) fn error_to_retry_reason(err: &Error) -> Option<RetryReason> {
     match err.kind.as_ref() {
-        ErrorKind::Memdx(e) => {
-            if e.is_notmyvbucket_error() {
+        ErrorKind::Memdx { source, .. } => {
+            if source.is_notmyvbucket_error() {
                 return Some(RetryReason::NotMyVbucket);
             }
-            if e.is_tmp_fail_error() {
+            if source.is_tmp_fail_error() {
                 return Some(RetryReason::TempFail);
             }
         }

--- a/sdk/couchbase-core/src/util.rs
+++ b/sdk/couchbase-core/src/util.rs
@@ -18,3 +18,58 @@ pub(crate) fn get_host_from_uri(uri: &str) -> error::Result<Option<String>> {
 
     Ok(Some(host))
 }
+
+pub(crate) fn hostname_from_addr_str(addr: &str) -> String {
+    let (host, _) = match split_host_port(addr) {
+        Ok(hp) => hp,
+        Err(_e) => return addr.to_string(),
+    };
+    host.to_string()
+}
+
+fn split_host_port(hostport: &str) -> error::Result<(&str, &str)> {
+    const MISSING_PORT: &str = "missing port in address";
+    const TOO_MANY_COLONS: &str = "too many colons in address";
+
+    let addr_err = |addr: &str, why: &str| -> error::Result<(&str, &str)> {
+        Err(ErrorKind::InvalidArgument {
+            msg: format!("invalid address '{}': {}", addr, why),
+        }
+        .into())
+    };
+
+    let i = hostport
+        .rfind(':')
+        .ok_or_else(|| ErrorKind::InvalidArgument {
+            msg: MISSING_PORT.to_string(),
+        })?;
+
+    if let Some(stripped) = hostport.strip_prefix('[') {
+        let end = hostport
+            .find(']')
+            .ok_or_else(|| ErrorKind::InvalidArgument {
+                msg: "missing ']' in address".to_string(),
+            })?;
+        if end + 1 == hostport.len() {
+            return addr_err(hostport, MISSING_PORT);
+        } else if end + 1 != i {
+            if hostport.chars().nth(end + 1) == Some(':') {
+                return addr_err(hostport, TOO_MANY_COLONS);
+            }
+            return addr_err(hostport, MISSING_PORT);
+        }
+        let host = &hostport[1..end];
+        let port = &hostport[i + 1..];
+        if stripped.contains('[') || hostport[end + 1..].contains(']') {
+            return addr_err(hostport, "unexpected '[' or ']' in address");
+        }
+        Ok((host, port))
+    } else {
+        let host = &hostport[..i];
+        if host.contains(':') {
+            return addr_err(hostport, TOO_MANY_COLONS);
+        }
+        let port = &hostport[i + 1..];
+        Ok((host, port))
+    }
+}

--- a/sdk/couchbase-core/tests/agent_manager.rs
+++ b/sdk/couchbase-core/tests/agent_manager.rs
@@ -10,9 +10,9 @@ mod common;
 
 #[tokio::test]
 async fn test_get_cluster_agent() {
-    setup_tests();
+    setup_tests().await;
 
-    let agent_opts = OnDemandAgentManagerOptions::from(create_default_options());
+    let agent_opts = OnDemandAgentManagerOptions::from(create_default_options().await);
 
     let mgr = OnDemandAgentManager::new(agent_opts).await.unwrap();
 
@@ -30,9 +30,9 @@ async fn test_get_cluster_agent() {
 
 #[tokio::test]
 async fn test_get_bucket_agent() {
-    setup_tests();
+    setup_tests().await;
 
-    let agent_opts = create_default_options();
+    let agent_opts = create_default_options().await;
     let bucket_name = agent_opts.bucket_name.clone().unwrap();
 
     let mgr_opts = OnDemandAgentManagerOptions::from(agent_opts);

--- a/sdk/couchbase-core/tests/common/default_agent_options.rs
+++ b/sdk/couchbase-core/tests/common/default_agent_options.rs
@@ -8,8 +8,8 @@ use {
     tokio_rustls::rustls::crypto::CryptoProvider,
 };
 
-pub fn create_default_options() -> AgentOptions {
-    let guard = TEST_CONFIG.lock().unwrap();
+pub async fn create_default_options() -> AgentOptions {
+    let guard = TEST_CONFIG.lock().await;
     let config = guard.clone().unwrap();
     drop(guard);
 
@@ -44,8 +44,8 @@ pub fn create_default_options() -> AgentOptions {
         .build()
 }
 
-pub fn create_options_without_bucket() -> AgentOptions {
-    let guard = TEST_CONFIG.lock().unwrap();
+pub async fn create_options_without_bucket() -> AgentOptions {
+    let guard = TEST_CONFIG.lock().await;
     let config = guard.clone().unwrap();
     drop(guard);
 

--- a/sdk/couchbase-core/tests/http.rs
+++ b/sdk/couchbase-core/tests/http.rs
@@ -27,15 +27,15 @@ struct TerseClusterInfo {
 
 #[tokio::test]
 async fn test_row_streamer() {
-    setup_tests();
+    setup_tests().await;
 
-    let addrs = test_mem_addrs();
+    let addrs = test_mem_addrs().await;
 
     let ip = addrs.first().unwrap().split(":").next().unwrap();
 
     let basic_auth = BasicAuth {
-        username: test_username(),
-        password: test_password(),
+        username: test_username().await,
+        password: test_password().await,
     };
 
     let request_body = json!({"statement": "FROM RANGE(0, 999) AS i SELECT *"});
@@ -99,14 +99,14 @@ async fn test_row_streamer() {
 
 #[tokio::test]
 async fn test_json_block_read() {
-    setup_tests();
+    setup_tests().await;
 
-    let addrs = test_mem_addrs();
+    let addrs = test_mem_addrs().await;
     let ip = addrs.first().unwrap().split(":").next().unwrap();
 
     let basic_auth = BasicAuth {
-        username: test_username(),
-        password: test_password(),
+        username: test_username().await,
+        password: test_password().await,
     };
     let uri = format!("http://{}:8091/pools/default/terseClusterInfo", ip);
 

--- a/sdk/couchbase-core/tests/query.rs
+++ b/sdk/couchbase-core/tests/query.rs
@@ -14,9 +14,9 @@ mod common;
 
 #[tokio::test]
 async fn test_query_basic() {
-    setup_tests();
+    setup_tests().await;
 
-    let agent_opts = create_default_options();
+    let agent_opts = create_default_options().await;
 
     let mut agent = Agent::new(agent_opts).await.unwrap();
     let opts = QueryOptions::builder()
@@ -69,9 +69,9 @@ async fn test_query_basic() {
 
 #[tokio::test]
 async fn test_prepared_query_basic() {
-    setup_tests();
+    setup_tests().await;
 
-    let agent_opts = create_default_options();
+    let agent_opts = create_default_options().await;
 
     let mut agent = Agent::new(agent_opts).await.unwrap();
     let opts = QueryOptions::builder()

--- a/sdk/couchbase/benches/collection_crud.rs
+++ b/sdk/couchbase/benches/collection_crud.rs
@@ -18,10 +18,10 @@ fn upsert(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -42,10 +42,10 @@ fn insert(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -66,10 +66,10 @@ fn replace(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -94,10 +94,10 @@ fn remove(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -119,10 +119,10 @@ fn exists(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -144,10 +144,10 @@ fn get(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -169,10 +169,10 @@ fn get_and_touch(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -197,10 +197,10 @@ fn get_and_lock(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -225,10 +225,10 @@ fn unlock(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -256,10 +256,10 @@ fn touch(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -284,10 +284,10 @@ fn append(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -322,10 +322,10 @@ fn prepend(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -360,10 +360,10 @@ fn increment(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();
@@ -385,10 +385,10 @@ fn decrement(c: &mut Criterion) {
         let cluster = create_cluster_from_test_config().await;
 
         cluster
-            .bucket(test_bucket())
+            .bucket(test_bucket().await)
             .await
-            .scope(test_scope())
-            .collection(test_collection())
+            .scope(test_scope().await)
+            .collection(test_collection().await)
     });
 
     let key = new_key();

--- a/sdk/couchbase/src/clients/cluster_client.rs
+++ b/sdk/couchbase/src/clients/cluster_client.rs
@@ -28,7 +28,7 @@ impl ClusterClient {
         opts: ClusterOptions,
     ) -> error::Result<ClusterClient> {
         let conn_spec = parse(conn_str)?;
-        let resolved_conn_spec = resolve(conn_spec)?;
+        let resolved_conn_spec = resolve(conn_spec).await?;
 
         let backend = if let Some(host) = resolved_conn_spec.couchbase2_host {
             ClusterClientBackend::Couchbase2ClusterBackend(

--- a/sdk/couchbase/tests/collection_crud.rs
+++ b/sdk/couchbase/tests/collection_crud.rs
@@ -15,15 +15,15 @@ mod common;
 
 #[tokio::test]
 async fn test_upsert() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -38,15 +38,15 @@ async fn test_upsert() {
 
 #[tokio::test]
 async fn test_upsert_with_transcoder() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let value = RawValue::from_string(r#"{"test": "test"}"#.to_string()).unwrap();
 
@@ -66,15 +66,15 @@ async fn test_upsert_with_transcoder() {
 
 #[tokio::test]
 async fn test_upsert_with_custom_transcoder() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let mut value = BTreeMap::new();
     value.insert("x".to_string(), 1.0);
@@ -104,15 +104,15 @@ async fn test_upsert_with_custom_transcoder() {
 
 #[tokio::test]
 async fn test_insert() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -127,15 +127,15 @@ async fn test_insert() {
 
 #[tokio::test]
 async fn test_replace() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -154,15 +154,15 @@ async fn test_replace() {
 
 #[tokio::test]
 async fn test_remove() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -176,15 +176,15 @@ async fn test_remove() {
 
 #[tokio::test]
 async fn test_exists() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -202,15 +202,15 @@ async fn test_exists() {
 
 #[tokio::test]
 async fn test_get_and_touch() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -228,15 +228,15 @@ async fn test_get_and_touch() {
 
 #[tokio::test]
 async fn test_get_and_lock() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -254,15 +254,15 @@ async fn test_get_and_lock() {
 
 #[tokio::test]
 async fn test_unlock() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -278,15 +278,15 @@ async fn test_unlock() {
 
 #[tokio::test]
 async fn test_touch() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -300,15 +300,15 @@ async fn test_touch() {
 
 #[tokio::test]
 async fn test_append() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -337,15 +337,15 @@ async fn test_append() {
 
 #[tokio::test]
 async fn test_prepend() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -374,15 +374,15 @@ async fn test_prepend() {
 
 #[tokio::test]
 async fn test_increment() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 
@@ -399,15 +399,15 @@ async fn test_increment() {
 
 #[tokio::test]
 async fn test_decrement() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
     let collection = cluster
-        .bucket(test_bucket())
+        .bucket(test_bucket().await)
         .await
-        .scope(test_scope())
-        .collection(test_collection());
+        .scope(test_scope().await)
+        .collection(test_collection().await);
 
     let key = new_key();
 

--- a/sdk/couchbase/tests/common/default_cluster_options.rs
+++ b/sdk/couchbase/tests/common/default_cluster_options.rs
@@ -2,8 +2,8 @@ use crate::common::test_config::TEST_CONFIG;
 use couchbase::options::cluster_options::{ClusterOptions, TlsOptions};
 use couchbase_core::authenticator::{Authenticator, PasswordAuthenticator};
 
-pub fn create_default_options() -> ClusterOptions {
-    let guard = TEST_CONFIG.read().unwrap();
+pub async fn create_default_options() -> ClusterOptions {
+    let guard = TEST_CONFIG.read().await;
     let config = guard.clone().unwrap();
     drop(guard);
 

--- a/sdk/couchbase/tests/common/mod.rs
+++ b/sdk/couchbase/tests/common/mod.rs
@@ -7,13 +7,13 @@ pub mod test_config;
 
 pub async fn create_cluster_from_test_config() -> Cluster {
     let config = {
-        let guard = test_config::TEST_CONFIG.read().unwrap();
+        let guard = test_config::TEST_CONFIG.read().await;
         guard.clone().unwrap()
     };
 
     Cluster::connect(
         config.conn_str.clone(),
-        default_cluster_options::create_default_options(),
+        default_cluster_options::create_default_options().await,
     )
     .await
     .unwrap()

--- a/sdk/couchbase/tests/common/test_config.rs
+++ b/sdk/couchbase/tests/common/test_config.rs
@@ -1,11 +1,15 @@
 use std::io::Write;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use couchbase_connstr::ResolvedConnSpec;
 use envconfig::Envconfig;
+use lazy_static::lazy_static;
 use log::LevelFilter;
+use tokio::sync::RwLock;
 
-pub static TEST_CONFIG: RwLock<Option<Arc<TestConfig>>> = RwLock::new(None);
+lazy_static! {
+    pub static ref TEST_CONFIG: RwLock<Option<Arc<TestConfig>>> = RwLock::new(None);
+}
 
 #[derive(Debug, Clone, Envconfig)]
 pub struct EnvTestConfig {
@@ -37,8 +41,8 @@ pub struct TestConfig {
     pub resolved_conn_spec: ResolvedConnSpec,
 }
 
-pub fn setup_tests(log_level: LevelFilter) {
-    let mut config = TEST_CONFIG.write().unwrap();
+pub async fn setup_tests(log_level: LevelFilter) {
+    let mut config = TEST_CONFIG.write().await;
 
     if config.is_none() {
         env_logger::Builder::new()
@@ -68,48 +72,49 @@ pub fn setup_tests(log_level: LevelFilter) {
             default_scope: test_config.default_scope,
             default_collection: test_config.default_collection,
             data_timeout: test_config.data_timeout,
-            resolved_conn_spec: couchbase_connstr::resolve(conn_spec).unwrap(),
+            resolved_conn_spec: couchbase_connstr::resolve(conn_spec).await.unwrap(),
         }));
     }
 }
-pub fn test_username() -> String {
-    let guard = TEST_CONFIG.read().unwrap();
+
+pub async fn test_username() -> String {
+    let guard = TEST_CONFIG.read().await;
     let config = guard.clone().unwrap();
     config.username.clone()
 }
 
-pub fn test_password() -> String {
-    let guard = TEST_CONFIG.read().unwrap();
+pub async fn test_password() -> String {
+    let guard = TEST_CONFIG.read().await;
     let config = guard.clone().unwrap();
     config.password.clone()
 }
 
-pub fn test_conn_str() -> String {
-    let guard = TEST_CONFIG.read().unwrap();
+pub async fn test_conn_str() -> String {
+    let guard = TEST_CONFIG.read().await;
     let config = guard.clone().unwrap();
     config.conn_str.clone()
 }
 
-pub fn test_bucket() -> String {
-    let guard = TEST_CONFIG.read().unwrap();
+pub async fn test_bucket() -> String {
+    let guard = TEST_CONFIG.read().await;
     let config = guard.clone().unwrap();
     config.default_bucket.clone()
 }
 
-pub fn test_scope() -> String {
-    let guard = TEST_CONFIG.read().unwrap();
+pub async fn test_scope() -> String {
+    let guard = TEST_CONFIG.read().await;
     let config = guard.clone().unwrap();
     config.default_scope.clone()
 }
 
-pub fn test_collection() -> String {
-    let guard = TEST_CONFIG.read().unwrap();
+pub async fn test_collection() -> String {
+    let guard = TEST_CONFIG.read().await;
     let config = guard.clone().unwrap();
     config.default_collection.clone()
 }
 
-pub fn test_data_timeout() -> String {
-    let guard = TEST_CONFIG.read().unwrap();
+pub async fn test_data_timeout() -> String {
+    let guard = TEST_CONFIG.read().await;
     let config = guard.clone().unwrap();
     config.data_timeout.clone()
 }

--- a/sdk/couchbase/tests/query.rs
+++ b/sdk/couchbase/tests/query.rs
@@ -11,7 +11,7 @@ mod common;
 
 #[tokio::test]
 async fn test_query_basic() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
@@ -37,7 +37,7 @@ async fn test_query_basic() {
 
 #[tokio::test]
 async fn test_query_raw_result() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
@@ -64,7 +64,7 @@ async fn test_query_raw_result() {
 
 #[tokio::test]
 async fn test_prepared_query_basic() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
@@ -90,10 +90,13 @@ async fn test_prepared_query_basic() {
 
 #[tokio::test]
 async fn test_scope_query_basic() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
-    let scope = cluster.bucket(test_bucket()).await.scope(test_scope());
+    let scope = cluster
+        .bucket(test_bucket().await)
+        .await
+        .scope(test_scope().await);
 
     let opts = QueryOptions::builder().metrics(true).build();
     let mut res = scope.query("SELECT 1=1", opts).await.unwrap();

--- a/sdk/couchbase/tests/search.rs
+++ b/sdk/couchbase/tests/search.rs
@@ -23,13 +23,16 @@ const BASIC_INDEX_NAME: &str = "basic_search_index";
 
 #[tokio::test]
 async fn test_search_basic() {
-    setup_tests(LevelFilter::Trace);
+    setup_tests(LevelFilter::Trace).await;
 
     let cluster = create_cluster_from_test_config().await;
 
-    let scope = cluster.bucket(test_bucket()).await.scope(test_scope());
+    let scope = cluster
+        .bucket(test_bucket().await)
+        .await
+        .scope(test_scope().await);
 
-    let collection = scope.collection(test_collection());
+    let collection = scope.collection(test_collection().await);
 
     let import_results = import_sample_beer_dataset("search", &collection).await;
 


### PR DESCRIPTION
Motivation
----------
We're currently replacing $HOST in configs with the endpoint reference rather than the source hostname.

Changes
-------
Refactors how we deal with remote hostnames and addresses from the memdx package, to lift addresses in errors up to the core level.
Fix SRV record resolving and connecting to FQDNs.