### PR TITLE
RSCBC-64: Make opening a bucket a background task

### DIFF
--- a/sdk/couchbase-core/src/agent.rs
+++ b/sdk/couchbase-core/src/agent.rs
@@ -6,13 +6,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::executor::block_on;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use tokio::net;
 use tokio::runtime::{Handle, Runtime};
 use tokio::sync::broadcast::{Receiver, Sender};
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::task::JoinHandle;
-use tokio::time::{timeout, timeout_at, Instant};
+use tokio::time::{sleep, timeout, timeout_at, Instant};
 
 use crate::agentoptions::AgentOptions;
 use crate::analyticscomponent::{
@@ -536,7 +536,10 @@ impl Agent {
                 let client: StdKvClient<Client> = match timeout_result {
                     Ok(client_result) => match client_result {
                         Ok(client) => client,
-                        Err(_e) => continue,
+                        Err(e) => {
+                            warn!("Failed to connect to endpoint: {}", e);
+                            continue;
+                        }
                     },
                     Err(_e) => continue,
                 };
@@ -557,6 +560,8 @@ impl Agent {
                     Err(_e) => continue,
                 };
             }
+            // TODO: Make configurable?
+            sleep(Duration::from_secs(1)).await;
         }
     }
 

--- a/sdk/couchbase-core/src/memdx/op_bootstrap.rs
+++ b/sdk/couchbase-core/src/memdx/op_bootstrap.rs
@@ -117,6 +117,7 @@ impl OpBootstrap {
                 Ok(_) => {}
                 Err(e) => {
                     warn!("Auth failed {}", e);
+                    return Err(e);
                 }
             };
         }
@@ -128,7 +129,7 @@ impl OpBootstrap {
                 Ok(r) => Some(r),
                 Err(e) => {
                     warn!("Select bucket failed {}", e);
-                    None
+                    return Err(e);
                 }
             };
         }

--- a/sdk/couchbase/Cargo.toml
+++ b/sdk/couchbase/Cargo.toml
@@ -4,18 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.83"
 bytes = "1.5.0"
 chrono = "0.4.38"
 futures = "0.3.30"
 lazy_static = "1.5.0"
 log = "0.4.22"
-regex = "1.11.0"
 serde = "1.0"
 serde_json = "1.0"
 typed-builder = "0.20.0"
-url = "2.5.2"
-urlencoding = "2.1.3"
 uuid = { version = "1.10.0", features = ["v4"] }
 webpki-roots = "0.26"
 
@@ -23,6 +19,7 @@ couchbase_connstr = { path = "../couchbase-connstr" }
 couchbase_core = { path = "../couchbase-core", default-features = false }
 rustls-pemfile = { version = "2.2", optional = true }
 
+tokio = { version = "1.42" }
 tokio-native-tls = { version = "0.3", optional = true }
 tokio-rustls = { version = "0.26.0", optional = true }
 

--- a/sdk/couchbase/benches/collection_crud.rs
+++ b/sdk/couchbase/benches/collection_crud.rs
@@ -10,16 +10,14 @@ use std::time::Duration;
 mod common;
 
 fn upsert(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -34,16 +32,14 @@ fn upsert(c: &mut Criterion) {
 }
 
 fn insert(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -58,16 +54,14 @@ fn insert(c: &mut Criterion) {
 }
 
 fn replace(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -86,16 +80,14 @@ fn replace(c: &mut Criterion) {
 }
 
 fn remove(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -111,16 +103,14 @@ fn remove(c: &mut Criterion) {
 }
 
 fn exists(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -136,16 +126,14 @@ fn exists(c: &mut Criterion) {
 }
 
 fn get(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -161,16 +149,14 @@ fn get(c: &mut Criterion) {
 }
 
 fn get_and_touch(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -189,16 +175,14 @@ fn get_and_touch(c: &mut Criterion) {
 }
 
 fn get_and_lock(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -217,16 +201,14 @@ fn get_and_lock(c: &mut Criterion) {
 }
 
 fn unlock(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -248,16 +230,14 @@ fn unlock(c: &mut Criterion) {
 }
 
 fn touch(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -276,16 +256,14 @@ fn touch(c: &mut Criterion) {
 }
 
 fn append(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -314,16 +292,14 @@ fn append(c: &mut Criterion) {
 }
 
 fn prepend(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -352,16 +328,14 @@ fn prepend(c: &mut Criterion) {
 }
 
 fn increment(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });
@@ -377,16 +351,14 @@ fn increment(c: &mut Criterion) {
 }
 
 fn decrement(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let collection = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
         let cluster = create_cluster_from_test_config().await;
 
         cluster
             .bucket(test_bucket().await)
-            .await
             .scope(test_scope().await)
             .collection(test_collection().await)
     });

--- a/sdk/couchbase/benches/query.rs
+++ b/sdk/couchbase/benches/query.rs
@@ -7,11 +7,12 @@ use log::LevelFilter;
 mod common;
 
 fn query(c: &mut Criterion) {
-    setup_tests(LevelFilter::Off);
-
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let cluster = rt.block_on(async { create_cluster_from_test_config().await });
+    let cluster = rt.block_on(async {
+        setup_tests(LevelFilter::Off).await;
+        create_cluster_from_test_config().await
+    });
 
     c.bench_function("query", |b| {
         b.to_async(&rt).iter(|| async {

--- a/sdk/couchbase/src/clients/agent_provider.rs
+++ b/sdk/couchbase/src/clients/agent_provider.rs
@@ -1,0 +1,71 @@
+use couchbase_core::agent::Agent;
+use couchbase_core::ondemand_agentmanager::OnDemandAgentManager;
+use std::sync::{Arc, RwLock};
+use tokio::sync::Notify;
+
+#[derive(Clone)]
+pub(crate) struct CouchbaseAgentProvider {
+    inner: Arc<CouchbaseAgentProviderInner>,
+    agent_create_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
+}
+
+struct CouchbaseAgentProviderInner {
+    agent: RwLock<Option<Agent>>,
+    waiter: Notify,
+}
+
+impl CouchbaseAgentProvider {
+    pub fn with_agent(agent: Agent) -> Self {
+        Self {
+            inner: Arc::new(CouchbaseAgentProviderInner {
+                agent: RwLock::new(Some(agent)),
+                waiter: Notify::new(),
+            }),
+            agent_create_handle: None,
+        }
+    }
+
+    pub fn with_bucket(agent_manager: Arc<OnDemandAgentManager>, bucket_name: String) -> Self {
+        let inner = Arc::new(CouchbaseAgentProviderInner {
+            agent: RwLock::new(None),
+            waiter: Notify::new(),
+        });
+
+        let inner_clone = inner.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let agent = match agent_manager.get_bucket_agent(bucket_name.clone()).await {
+                    Ok(agent) => agent,
+                    Err(e) => {
+                        log::error!("failed to get agent for bucket {}: {}", bucket_name, e);
+                        continue;
+                    }
+                };
+                {
+                    let mut guard = inner_clone.agent.write().unwrap();
+                    *guard = Some(agent);
+                }
+                inner_clone.waiter.notify_waiters();
+                return;
+            }
+        });
+
+        Self {
+            inner,
+            agent_create_handle: Some(Arc::new(handle)),
+        }
+    }
+
+    // get_agent will return the agent if it is already available, otherwise it will wait until it is available.
+    pub async fn get_agent(&self) -> Agent {
+        {
+            let guard = self.inner.agent.read().unwrap();
+            if let Some(agent) = guard.as_ref() {
+                return agent.clone();
+            }
+        }
+
+        self.inner.waiter.notified().await;
+        Box::pin(self.get_agent()).await
+    }
+}

--- a/sdk/couchbase/src/clients/bucket_client.rs
+++ b/sdk/couchbase/src/clients/bucket_client.rs
@@ -1,7 +1,7 @@
+use crate::clients::agent_provider::CouchbaseAgentProvider;
 use crate::clients::scope_client::{
     Couchbase2ScopeClient, CouchbaseScopeClient, ScopeClient, ScopeClientBackend,
 };
-use couchbase_core::agent::Agent;
 use couchbase_core::retry::RetryStrategy;
 use std::sync::Arc;
 
@@ -40,15 +40,19 @@ pub(crate) enum BucketClientBackend {
 
 #[derive(Clone)]
 pub(crate) struct CouchbaseBucketClient {
-    agent: Agent,
+    agent_provider: CouchbaseAgentProvider,
     name: String,
     default_retry_strategy: Arc<dyn RetryStrategy>,
 }
 
 impl CouchbaseBucketClient {
-    pub fn new(agent: Agent, name: String, default_retry_strategy: Arc<dyn RetryStrategy>) -> Self {
+    pub fn new(
+        agent_provider: CouchbaseAgentProvider,
+        name: String,
+        default_retry_strategy: Arc<dyn RetryStrategy>,
+    ) -> Self {
         Self {
-            agent,
+            agent_provider,
             name,
             default_retry_strategy,
         }
@@ -61,7 +65,7 @@ impl CouchbaseBucketClient {
     pub fn scope(&self, name: String) -> ScopeClient {
         ScopeClient::new(ScopeClientBackend::CouchbaseScopeBackend(
             CouchbaseScopeClient::new(
-                self.agent.clone(),
+                self.agent_provider.clone(),
                 self.name().to_string(),
                 name,
                 self.default_retry_strategy.clone(),

--- a/sdk/couchbase/src/clients/collection_client.rs
+++ b/sdk/couchbase/src/clients/collection_client.rs
@@ -1,6 +1,6 @@
+use crate::clients::agent_provider::CouchbaseAgentProvider;
 use crate::clients::core_kv_client::{CoreKvClient, CoreKvClientBackend, Couchbase2CoreKvClient};
 use crate::clients::couchbase_core_kv_client::CouchbaseCoreKvClient;
-use couchbase_core::agent::Agent;
 use couchbase_core::retry::RetryStrategy;
 use std::sync::Arc;
 
@@ -37,7 +37,7 @@ pub(crate) enum CollectionClientBackend {
 
 #[derive(Clone)]
 pub(crate) struct CouchbaseCollectionClient {
-    agent: Agent,
+    agent_provider: CouchbaseAgentProvider,
     bucket_name: String,
     scope_name: String,
     name: String,
@@ -46,14 +46,14 @@ pub(crate) struct CouchbaseCollectionClient {
 
 impl CouchbaseCollectionClient {
     pub fn new(
-        agent: Agent,
+        agent_provider: CouchbaseAgentProvider,
         bucket_name: String,
         scope_name: String,
         name: String,
         default_retry_strategy: Arc<dyn RetryStrategy>,
     ) -> Self {
         Self {
-            agent,
+            agent_provider,
             bucket_name,
             scope_name,
             name,
@@ -76,7 +76,7 @@ impl CouchbaseCollectionClient {
     pub fn core_kv_client(&self) -> CoreKvClient {
         CoreKvClient::new(CoreKvClientBackend::CouchbaseCoreKvClientBackend(
             CouchbaseCoreKvClient::new(
-                self.agent.clone(),
+                self.agent_provider.clone(),
                 self.bucket_name().to_string(),
                 self.scope_name().to_string(),
                 self.name().to_string(),

--- a/sdk/couchbase/src/clients/mod.rs
+++ b/sdk/couchbase/src/clients/mod.rs
@@ -1,3 +1,4 @@
+mod agent_provider;
 pub mod analytics_client;
 pub mod bucket_client;
 pub mod cluster_client;

--- a/sdk/couchbase/src/clients/query_client.rs
+++ b/sdk/couchbase/src/clients/query_client.rs
@@ -1,7 +1,7 @@
+use crate::clients::agent_provider::CouchbaseAgentProvider;
 use crate::error;
 use crate::options::query_options::QueryOptions;
 use crate::results::query_results::QueryResult;
-use couchbase_core::agent::Agent;
 use uuid::Uuid;
 
 pub(crate) struct QueryClient {
@@ -40,21 +40,21 @@ pub(crate) struct QueryKeyspace {
 }
 
 pub(crate) struct CouchbaseQueryClient {
-    agent: Agent,
+    agent_provider: CouchbaseAgentProvider,
     keyspace: Option<QueryKeyspace>,
 }
 
 impl CouchbaseQueryClient {
-    pub fn new(agent: Agent) -> Self {
+    pub fn new(agent_provider: CouchbaseAgentProvider) -> Self {
         Self {
-            agent,
+            agent_provider,
             keyspace: None,
         }
     }
 
-    pub fn with_keyspace(agent: Agent, keyspace: QueryKeyspace) -> Self {
+    pub fn with_keyspace(agent_provider: CouchbaseAgentProvider, keyspace: QueryKeyspace) -> Self {
         Self {
-            agent,
+            agent_provider,
             keyspace: Some(keyspace),
         }
     }
@@ -82,12 +82,11 @@ impl CouchbaseQueryClient {
             ));
         }
 
+        let agent = self.agent_provider.get_agent().await;
         if ad_hoc {
-            Ok(QueryResult::from(self.agent.query(query_opts).await?))
+            Ok(QueryResult::from(agent.query(query_opts).await?))
         } else {
-            Ok(QueryResult::from(
-                self.agent.prepared_query(query_opts).await?,
-            ))
+            Ok(QueryResult::from(agent.prepared_query(query_opts).await?))
         }
     }
 }

--- a/sdk/couchbase/src/clients/scope_client.rs
+++ b/sdk/couchbase/src/clients/scope_client.rs
@@ -1,3 +1,4 @@
+use crate::clients::agent_provider::CouchbaseAgentProvider;
 use crate::clients::analytics_client::{
     AnalyticsClient, AnalyticsClientBackend, AnalyticsKeyspace, CouchbaseAnalyticsClient,
 };
@@ -11,7 +12,6 @@ use crate::clients::query_client::{
 use crate::clients::search_client::{
     CouchbaseSearchClient, SearchClient, SearchClientBackend, SearchKeyspace,
 };
-use couchbase_core::agent::Agent;
 use couchbase_core::retry::RetryStrategy;
 use std::sync::Arc;
 
@@ -95,7 +95,7 @@ pub(crate) enum ScopeClientBackend {
 
 #[derive(Clone)]
 pub(crate) struct CouchbaseScopeClient {
-    agent: Agent,
+    agent_provider: CouchbaseAgentProvider,
     bucket_name: String,
     name: String,
     default_retry_strategy: Arc<dyn RetryStrategy>,
@@ -103,13 +103,13 @@ pub(crate) struct CouchbaseScopeClient {
 
 impl CouchbaseScopeClient {
     pub fn new(
-        agent: Agent,
+        agent_provider: CouchbaseAgentProvider,
         bucket_name: String,
         name: String,
         default_retry_strategy: Arc<dyn RetryStrategy>,
     ) -> Self {
         Self {
-            agent,
+            agent_provider,
             bucket_name,
             name,
             default_retry_strategy,
@@ -127,7 +127,7 @@ impl CouchbaseScopeClient {
     pub fn collection(&self, name: String) -> CollectionClient {
         CollectionClient::new(CollectionClientBackend::CouchbaseCollectionBackend(
             CouchbaseCollectionClient::new(
-                self.agent.clone(),
+                self.agent_provider.clone(),
                 self.bucket_name().to_string(),
                 self.name().to_string(),
                 name,
@@ -138,7 +138,7 @@ impl CouchbaseScopeClient {
 
     pub fn query_client(&self) -> CouchbaseQueryClient {
         CouchbaseQueryClient::with_keyspace(
-            self.agent.clone(),
+            self.agent_provider.clone(),
             QueryKeyspace {
                 bucket_name: self.bucket_name().to_string(),
                 scope_name: self.name().to_string(),
@@ -148,7 +148,7 @@ impl CouchbaseScopeClient {
 
     pub fn search_client(&self) -> CouchbaseSearchClient {
         CouchbaseSearchClient::with_keyspace(
-            self.agent.clone(),
+            self.agent_provider.clone(),
             SearchKeyspace {
                 bucket_name: self.bucket_name().to_string(),
                 scope_name: self.name().to_string(),
@@ -158,7 +158,7 @@ impl CouchbaseScopeClient {
 
     pub fn analytics_client(&self) -> CouchbaseAnalyticsClient {
         CouchbaseAnalyticsClient::with_keyspace(
-            self.agent.clone(),
+            self.agent_provider.clone(),
             AnalyticsKeyspace {
                 bucket_name: self.bucket_name().to_string(),
                 scope_name: self.name().to_string(),

--- a/sdk/couchbase/src/clients/search_client.rs
+++ b/sdk/couchbase/src/clients/search_client.rs
@@ -1,8 +1,8 @@
+use crate::clients::agent_provider::CouchbaseAgentProvider;
 use crate::error;
 use crate::options::search_options::SearchOptions;
 use crate::results::search_results::SearchResult;
 use crate::search::request::SearchRequest;
-use couchbase_core::agent::Agent;
 use couchbase_core::searchx;
 use couchbase_core::searchx::query_options::{
     Consistency, ConsistencyLevel, ConsistencyVectors, Control, KnnOperator, KnnQuery,
@@ -46,21 +46,21 @@ pub(crate) struct SearchKeyspace {
 }
 
 pub(crate) struct CouchbaseSearchClient {
-    agent: Agent,
+    agent_provider: CouchbaseAgentProvider,
     keyspace: Option<SearchKeyspace>,
 }
 
 impl CouchbaseSearchClient {
-    pub fn new(agent: Agent) -> Self {
+    pub fn new(agent_provider: CouchbaseAgentProvider) -> Self {
         Self {
-            agent,
+            agent_provider,
             keyspace: None,
         }
     }
 
-    pub fn with_keyspace(agent: Agent, keyspace: SearchKeyspace) -> Self {
+    pub fn with_keyspace(agent_provider: CouchbaseAgentProvider, keyspace: SearchKeyspace) -> Self {
         Self {
-            agent,
+            agent_provider,
             keyspace: Some(keyspace),
         }
     }
@@ -196,7 +196,8 @@ impl CouchbaseSearchClient {
             .retry_strategy(opts.retry_strategy)
             .build();
 
-        Ok(SearchResult::from(self.agent.search(core_opts).await?))
+        let agent = self.agent_provider.get_agent().await;
+        Ok(SearchResult::from(agent.search(core_opts).await?))
     }
 }
 

--- a/sdk/couchbase/src/cluster.rs
+++ b/sdk/couchbase/src/cluster.rs
@@ -41,9 +41,8 @@ impl Cluster {
         })
     }
 
-    pub async fn bucket(&self, name: impl Into<String>) -> Bucket {
-        // TODO: unwrap
-        let bucket_client = self.client.bucket_client(name.into()).await.unwrap();
+    pub fn bucket(&self, name: impl Into<String>) -> Bucket {
+        let bucket_client = self.client.bucket_client(name.into());
 
         Bucket::new(bucket_client)
     }

--- a/sdk/couchbase/tests/bucket.rs
+++ b/sdk/couchbase/tests/bucket.rs
@@ -1,0 +1,32 @@
+use crate::common::test_config::{setup_tests, test_collection, test_scope};
+use crate::common::{create_cluster_from_test_config, new_key};
+use log::LevelFilter;
+use std::ops::Add;
+use std::time::Duration;
+use tokio::time::{timeout_at, Instant};
+
+mod common;
+
+#[tokio::test]
+async fn test_upsert() {
+    setup_tests(LevelFilter::Trace).await;
+
+    let cluster = create_cluster_from_test_config().await;
+
+    let collection = cluster
+        .bucket("idonotexistonthiscluster")
+        .scope(test_scope().await)
+        .collection(test_collection().await);
+
+    let key = new_key();
+
+    if timeout_at(
+        Instant::now().add(Duration::from_millis(2500)),
+        collection.upsert(&key, "test", None),
+    )
+    .await
+    .is_ok()
+    {
+        panic!("expected timeout");
+    }
+}

--- a/sdk/couchbase/tests/collection_crud.rs
+++ b/sdk/couchbase/tests/collection_crud.rs
@@ -24,7 +24,6 @@ async fn test_upsert() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -47,7 +46,6 @@ async fn test_upsert_with_transcoder() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -75,7 +73,6 @@ async fn test_upsert_with_custom_transcoder() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -113,7 +110,6 @@ async fn test_insert() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -136,7 +132,6 @@ async fn test_replace() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -163,7 +158,6 @@ async fn test_remove() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -185,7 +179,6 @@ async fn test_exists() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -211,7 +204,6 @@ async fn test_get_and_touch() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -237,7 +229,6 @@ async fn test_get_and_lock() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -263,7 +254,6 @@ async fn test_unlock() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -287,7 +277,6 @@ async fn test_touch() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -309,7 +298,6 @@ async fn test_append() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -346,7 +334,6 @@ async fn test_prepend() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -383,7 +370,6 @@ async fn test_increment() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -408,7 +394,6 @@ async fn test_decrement() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -441,7 +426,6 @@ async fn test_lookup_in() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 
@@ -492,7 +476,6 @@ async fn test_mutate_in() {
 
     let collection = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await)
         .collection(test_collection().await);
 

--- a/sdk/couchbase/tests/common/test_config.rs
+++ b/sdk/couchbase/tests/common/test_config.rs
@@ -17,7 +17,7 @@ pub struct EnvTestConfig {
     pub username: String,
     #[envconfig(from = "RCBPASSWORD", default = "password")]
     pub password: String,
-    #[envconfig(from = "RCBCONNSTR", default = "couchbases://192.168.107.128")]
+    #[envconfig(from = "RCBCONNSTR", default = "couchbases://192.168.107.129")]
     pub conn_string: String,
     #[envconfig(from = "RCBBUCKET", default = "default")]
     pub default_bucket: String,

--- a/sdk/couchbase/tests/query.rs
+++ b/sdk/couchbase/tests/query.rs
@@ -95,7 +95,6 @@ async fn test_scope_query_basic() {
     let cluster = create_cluster_from_test_config().await;
     let scope = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await);
 
     let opts = QueryOptions::builder().metrics(true).build();

--- a/sdk/couchbase/tests/search.rs
+++ b/sdk/couchbase/tests/search.rs
@@ -29,7 +29,6 @@ async fn test_search_basic() {
 
     let scope = cluster
         .bucket(test_bucket().await)
-        .await
         .scope(test_scope().await);
 
     let collection = scope.collection(test_collection().await);


### PR DESCRIPTION
Motivation
----------
The call to cluster.bucket is supposed to be synchronous and not return a result. At present it's async and has an unwrap in it.

Changes
-------
Add an agent provider which spawns a task to get an agent at the bucket level.
Obtain agents in clients via the provider.