### PR TITLE
RSCBC-65: Add http fallback for fetching first config

### DIFF
--- a/sdk/couchbase-core/src/error.rs
+++ b/sdk/couchbase-core/src/error.rs
@@ -1,6 +1,7 @@
 use crate::analyticsx::error::Error as AnalyticsError;
 use crate::httpx::error::Error as HttpError;
 use crate::memdx::error::Error as MemdxError;
+use crate::mgmtx::error::Error as MgmtError;
 use crate::queryx::error::Error as QueryError;
 use crate::searchx::error::Error as SearchError;
 use crate::service_type::ServiceType;
@@ -91,6 +92,8 @@ pub enum ErrorKind {
     Analytics(AnalyticsError),
     #[error("{0}")]
     Http(HttpError),
+    #[error("{0}")]
+    Mgmt(MgmtError),
     #[error("Endpoint not known {endpoint}")]
     #[non_exhaustive]
     EndpointNotKnown { endpoint: String },
@@ -156,6 +159,12 @@ impl From<SearchError> for Error {
 impl From<AnalyticsError> for Error {
     fn from(value: AnalyticsError) -> Self {
         Self::new(ErrorKind::Analytics(value))
+    }
+}
+
+impl From<MgmtError> for Error {
+    fn from(value: MgmtError) -> Self {
+        Self::new(ErrorKind::Mgmt(value))
     }
 }
 

--- a/sdk/couchbase-core/src/lib.rs
+++ b/sdk/couchbase-core/src/lib.rs
@@ -31,6 +31,7 @@ mod kvclient_ops;
 mod kvclientmanager;
 mod kvclientpool;
 pub mod memdx;
+pub mod mgmtx;
 pub mod mutationtoken;
 mod networktypeheuristic;
 mod nmvbhandler;

--- a/sdk/couchbase-core/src/mgmtx/error.rs
+++ b/sdk/couchbase-core/src/mgmtx/error.rs
@@ -1,0 +1,95 @@
+use http::StatusCode;
+use std::error::Error as StdError;
+use std::fmt::Display;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Error {
+    pub kind: Box<ErrorKind>,
+
+    pub source: Option<Box<dyn StdError + 'static + Send + Sync>>,
+}
+
+impl StdError for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(source) = &self.source {
+            write!(f, "{}, caused by: {}", self.kind, source)
+        } else {
+            write!(f, "{}", self.kind)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ErrorKind {
+    #[non_exhaustive]
+    Server {
+        status_code: StatusCode,
+        body: String,
+        kind: ServerErrorKind,
+    },
+    #[non_exhaustive]
+    Generic { msg: String },
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ErrorKind::Server {
+                status_code,
+                body,
+                kind,
+            } => write!(
+                f,
+                "server error: status code: {}, body: {}, kind: {}",
+                status_code, body, kind
+            ),
+            ErrorKind::Generic { msg } => write!(f, "generic error: {}", msg),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub enum ServerErrorKind {
+    AccessDenied,
+    UnsupportedFeature,
+    ScopeExists,
+    ScopeNotFound,
+    CollectionExists,
+    CollectionNotFound,
+    BucketExists,
+    BucketNotFound,
+    FlushDisabled,
+    ServerInvalidArg,
+    BucketUuidMismatch,
+    UserNotFound,
+    OperationDelayed,
+    Unknown,
+}
+
+impl Display for ServerErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServerErrorKind::AccessDenied => write!(f, "access denied"),
+            ServerErrorKind::UnsupportedFeature => write!(f, "unsupported feature"),
+            ServerErrorKind::ScopeExists => write!(f, "scope exists"),
+            ServerErrorKind::ScopeNotFound => write!(f, "scope not found"),
+            ServerErrorKind::CollectionExists => write!(f, "collection exists"),
+            ServerErrorKind::CollectionNotFound => write!(f, "collection not found"),
+            ServerErrorKind::BucketExists => write!(f, "bucket exists"),
+            ServerErrorKind::BucketNotFound => write!(f, "bucket not found"),
+            ServerErrorKind::FlushDisabled => write!(f, "flush disabled"),
+            ServerErrorKind::ServerInvalidArg => write!(f, "server invalid argument"),
+            ServerErrorKind::BucketUuidMismatch => write!(f, "bucket uuid mismatch"),
+            ServerErrorKind::UserNotFound => write!(f, "user not found"),
+            ServerErrorKind::OperationDelayed => {
+                write!(f, "operation was delayed, but will continue")
+            }
+            ServerErrorKind::Unknown => write!(f, "unknown error"),
+        }
+    }
+}

--- a/sdk/couchbase-core/src/mgmtx/mgmt.rs
+++ b/sdk/couchbase-core/src/mgmtx/mgmt.rs
@@ -1,0 +1,279 @@
+use crate::cbconfig::TerseConfig;
+use crate::httpx::client::Client;
+use crate::httpx::request::{Auth, BasicAuth, OnBehalfOfInfo, Request};
+use crate::httpx::response::Response;
+use crate::mgmtx::error;
+use bytes::Bytes;
+use http::Method;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+lazy_static! {
+    static ref FIELD_NAME_MAP: HashMap<String, String> = {
+        HashMap::from([
+            (
+                "durability_min_level".to_string(),
+                "DurabilityMinLevel".to_string(),
+            ),
+            ("ramquota".to_string(), "RamQuotaMB".to_string()),
+            ("replicanumber".to_string(), "ReplicaNumber".to_string()),
+            ("maxttl".to_string(), "MaxTTL".to_string()),
+            ("history".to_string(), "HistoryEnabled".to_string()),
+        ])
+    };
+}
+
+#[derive(Debug)]
+pub struct Management<C: Client> {
+    pub http_client: Arc<C>,
+    pub user_agent: String,
+    pub endpoint: String,
+    pub username: String,
+    pub password: String,
+}
+
+impl<C: Client> Management<C> {
+    pub fn new_request(
+        &self,
+        method: Method,
+        path: impl Into<String>,
+        content_type: impl Into<String>,
+        on_behalf_of: Option<OnBehalfOfInfo>,
+        headers: Option<HashMap<&str, &str>>,
+        body: Option<Bytes>,
+    ) -> Request {
+        let auth = if let Some(obo) = on_behalf_of {
+            Auth::OnBehalfOf(OnBehalfOfInfo {
+                username: obo.username,
+                password_or_domain: obo.password_or_domain,
+            })
+        } else {
+            Auth::BasicAuth(BasicAuth {
+                username: self.username.clone(),
+                password: self.password.clone(),
+            })
+        };
+
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(format!("{}/{}", self.endpoint, path.into()))
+            .auth(auth)
+            .user_agent(self.user_agent.clone())
+            .content_type(content_type.into())
+            .body(body);
+
+        if let Some(headers) = headers {
+            for (key, value) in headers.into_iter() {
+                builder = builder.add_header(key, value);
+            }
+        }
+
+        builder.build()
+    }
+
+    pub async fn execute(
+        &self,
+        method: Method,
+        path: impl Into<String>,
+        content_type: impl Into<String>,
+        on_behalf_of: Option<OnBehalfOfInfo>,
+        headers: Option<HashMap<&str, &str>>,
+        body: Option<Bytes>,
+    ) -> crate::httpx::error::Result<Response> {
+        let req = self.new_request(method, path, content_type, on_behalf_of, headers, body);
+
+        self.http_client.execute(req).await
+    }
+
+    async fn decode_common_error(response: Response) -> error::Error {
+        let status = response.status();
+        let body = match response.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                return error::Error {
+                    kind: Box::new(error::ErrorKind::Generic {
+                        msg: format!("could not parse response body: {}", e),
+                    }),
+                    source: Some(Box::new(e)),
+                }
+            }
+        };
+
+        let body_str = match String::from_utf8(body.to_vec()) {
+            Ok(s) => s.to_lowercase(),
+            Err(e) => {
+                return error::Error {
+                    kind: Box::new(error::ErrorKind::Generic {
+                        msg: format!("could not parse error response: {}", e),
+                    }),
+                    source: Some(Box::new(e)),
+                }
+            }
+        };
+
+        let kind = if body_str.contains("not found") && body_str.contains("collection") {
+            error::ServerErrorKind::CollectionNotFound
+        } else if body_str.contains("not found") && body_str.contains("scope") {
+            error::ServerErrorKind::ScopeNotFound
+        } else if body_str.contains("not found") && body_str.contains("bucket") {
+            error::ServerErrorKind::BucketNotFound
+        } else if body_str.contains("not found") && body_str.contains("user") {
+            error::ServerErrorKind::UserNotFound
+        } else if body_str.contains("already exists") && body_str.contains("collection") {
+            error::ServerErrorKind::CollectionExists
+        } else if body_str.contains("already exists") && body_str.contains("scope") {
+            error::ServerErrorKind::ScopeExists
+        } else if body_str.contains("already exists") && body_str.contains("bucket") {
+            error::ServerErrorKind::BucketExists
+        } else if body_str.contains("flush is disabled") {
+            error::ServerErrorKind::FlushDisabled
+        } else if body_str.contains("requested resource not found")
+            || body_str.contains("non existent bucket")
+        {
+            error::ServerErrorKind::BucketNotFound
+        } else if body_str.contains("not yet complete, but will continue") {
+            error::ServerErrorKind::OperationDelayed
+        } else if status == 400 {
+            let s_err = Self::parse_for_invalid_arg(&body_str);
+            if let Some(ia) = s_err {
+                let key = ia.0;
+                if FIELD_NAME_MAP.contains_key(&key) {
+                    error::ServerErrorKind::ServerInvalidArg
+                } else {
+                    error::ServerErrorKind::Unknown
+                }
+            } else if body_str.contains("not allowed on this type of bucket") {
+                error::ServerErrorKind::ServerInvalidArg
+            } else {
+                error::ServerErrorKind::Unknown
+            }
+        } else if status == 404 {
+            error::ServerErrorKind::UnsupportedFeature
+        } else if status == 401 {
+            error::ServerErrorKind::AccessDenied
+        } else {
+            error::ServerErrorKind::Unknown
+        };
+
+        error::Error {
+            kind: Box::new(error::ErrorKind::Server {
+                status_code: status,
+                body: body_str,
+                kind,
+            }),
+            source: None,
+        }
+    }
+
+    fn parse_for_invalid_arg(body: &str) -> Option<(String, String)> {
+        let inv_arg: ServerErrors = match serde_json::from_str(body) {
+            Ok(i) => i,
+            Err(_e) => {
+                return None;
+            }
+        };
+
+        if let Some((k, v)) = inv_arg.errors.into_iter().next() {
+            return Some((k, v));
+        }
+
+        None
+    }
+
+    pub async fn get_terse_cluster_config(
+        &self,
+        opts: GetTerseClusterConfigOptions,
+    ) -> error::Result<TerseConfig> {
+        let resp = self
+            .execute(
+                Method::GET,
+                "/pools/default/nodeServicesStreaming",
+                "",
+                opts.on_behalf_of_info,
+                None,
+                None,
+            )
+            .await
+            .map_err(|e| error::Error {
+                kind: Box::new(error::ErrorKind::Generic {
+                    msg: format!("could not get cluster config: {}", e),
+                }),
+                source: Some(Box::new(e)),
+            })?;
+
+        if resp.status() != 200 {
+            return Err(Self::decode_common_error(resp).await);
+        }
+
+        let body = resp.bytes().await.map_err(|e| error::Error {
+            kind: Box::new(error::ErrorKind::Generic {
+                msg: format!("could not read response: {}", e),
+            }),
+            source: Some(Box::new(e)),
+        })?;
+
+        serde_json::from_slice(&body).map_err(|e| error::Error {
+            kind: Box::new(error::ErrorKind::Generic {
+                msg: format!("could not parse response: {}", e),
+            }),
+            source: Some(Box::new(e)),
+        })
+    }
+
+    pub async fn get_terse_bucket_config(
+        &self,
+        opts: GetTerseBucketConfigOptions,
+    ) -> error::Result<TerseConfig> {
+        let resp = self
+            .execute(
+                Method::GET,
+                format!("/pools/default/b/{}", opts.bucket_name),
+                "",
+                opts.on_behalf_of_info,
+                None,
+                None,
+            )
+            .await
+            .map_err(|e| error::Error {
+                kind: Box::new(error::ErrorKind::Generic {
+                    msg: format!("could not get cluster config: {}", e),
+                }),
+                source: Some(Box::new(e)),
+            })?;
+
+        if resp.status() != 200 {
+            return Err(Self::decode_common_error(resp).await);
+        }
+
+        let body = resp.bytes().await.map_err(|e| error::Error {
+            kind: Box::new(error::ErrorKind::Generic {
+                msg: format!("could not read response: {}", e),
+            }),
+            source: Some(Box::new(e)),
+        })?;
+
+        serde_json::from_slice(&body).map_err(|e| error::Error {
+            kind: Box::new(error::ErrorKind::Generic {
+                msg: format!("could not parse response: {}", e),
+            }),
+            source: Some(Box::new(e)),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GetTerseClusterConfigOptions {
+    pub on_behalf_of_info: Option<OnBehalfOfInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GetTerseBucketConfigOptions {
+    pub on_behalf_of_info: Option<OnBehalfOfInfo>,
+    pub bucket_name: String,
+}
+
+#[derive(Deserialize)]
+struct ServerErrors {
+    errors: HashMap<String, String>,
+}

--- a/sdk/couchbase-core/src/mgmtx/mod.rs
+++ b/sdk/couchbase-core/src/mgmtx/mod.rs
@@ -1,0 +1,2 @@
+pub mod error;
+pub mod mgmt;

--- a/sdk/couchbase-core/src/util.rs
+++ b/sdk/couchbase-core/src/util.rs
@@ -3,7 +3,7 @@ use url::Url;
 use crate::error;
 use crate::error::ErrorKind;
 
-pub(crate) fn get_host_from_uri(uri: &str) -> error::Result<Option<String>> {
+pub(crate) fn get_host_port_from_uri(uri: &str) -> error::Result<String> {
     let parsed = Url::parse(uri).map_err(|e| ErrorKind::Generic { msg: e.to_string() })?;
 
     let host = if let Some(host) = parsed.host() {
@@ -13,10 +13,13 @@ pub(crate) fn get_host_from_uri(uri: &str) -> error::Result<Option<String>> {
             host.to_string()
         }
     } else {
-        return Ok(None);
+        return Err(ErrorKind::Generic {
+            msg: "invalid endpoint".to_string(),
+        }
+        .into());
     };
 
-    Ok(Some(host))
+    Ok(host)
 }
 
 pub(crate) fn hostname_from_addr_str(addr: &str) -> String {
@@ -25,6 +28,16 @@ pub(crate) fn hostname_from_addr_str(addr: &str) -> String {
         Err(_e) => return addr.to_string(),
     };
     host.to_string()
+}
+
+pub(crate) fn get_hostname_from_host_port(host_port: &str) -> error::Result<String> {
+    let (host, _) = split_host_port(host_port)?;
+
+    if host.contains(':') {
+        return Ok(format!("[{}]", host));
+    }
+
+    Ok(host.to_string())
 }
 
 fn split_host_port(hostport: &str) -> error::Result<(&str, &str)> {

--- a/sdk/couchbase/src/clients/cluster_client.rs
+++ b/sdk/couchbase/src/clients/cluster_client.rs
@@ -42,6 +42,7 @@ impl ClusterClient {
             ClusterClientBackend::CouchbaseClusterBackend(
                 CouchbaseClusterBackend::connect(
                     resolved_conn_spec.memd_hosts,
+                    resolved_conn_spec.http_hosts,
                     resolved_conn_spec.srv_record,
                     resolved_conn_spec.use_ssl,
                     opts,
@@ -122,7 +123,8 @@ struct CouchbaseClusterBackend {
 
 impl CouchbaseClusterBackend {
     pub async fn connect(
-        hosts: Vec<Address>,
+        memd_hosts: Vec<Address>,
+        http_hosts: Vec<Address>,
         _srv_record: Option<SrvRecord>,
         use_ssl: bool,
         opts: ClusterOptions,
@@ -147,7 +149,8 @@ impl CouchbaseClusterBackend {
 
         Self::merge_options(&mut opts, extra_opts)?;
 
-        opts.seed_config.memd_addrs = hosts.iter().map(|a| a.to_string()).collect();
+        opts.seed_config.memd_addrs = memd_hosts.iter().map(|a| a.to_string()).collect();
+        opts.seed_config.http_addrs = http_hosts.iter().map(|a| a.to_string()).collect();
 
         let mgr = OnDemandAgentManager::new(opts).await?;
 

--- a/sdk/couchbase/tests/common/test_config.rs
+++ b/sdk/couchbase/tests/common/test_config.rs
@@ -17,7 +17,7 @@ pub struct EnvTestConfig {
     pub username: String,
     #[envconfig(from = "RCBPASSWORD", default = "password")]
     pub password: String,
-    #[envconfig(from = "RCBCONNSTR", default = "couchbases://192.168.107.129")]
+    #[envconfig(from = "RCBCONNSTR", default = "couchbases://192.168.107.128")]
     pub conn_string: String,
     #[envconfig(from = "RCBBUCKET", default = "default")]
     pub default_bucket: String,


### PR DESCRIPTION
Motivation
-----------
We currently cannot bootstrap a bucket agent against a non-kv node because select bucket fails. We need to add a http fallback to try fetch the config if all memd nodes fail.