### PR TITLE
RSCBC-84: Add support for specifying number of vbuckets when creating…

### DIFF
--- a/sdk/couchbase-core/src/mgmtx/bucket_settings.rs
+++ b/sdk/couchbase-core/src/mgmtx/bucket_settings.rs
@@ -20,6 +20,7 @@ pub struct BucketSettings {
     pub replica_index: Option<bool>,
     pub bucket_type: Option<BucketType>,
     pub storage_backend: Option<StorageBackend>,
+    pub num_vbuckets: Option<u16>,
 }
 
 impl BucketSettings {
@@ -101,6 +102,11 @@ impl BucketSettings {
         self.storage_backend = Some(storage_backend.into());
         self
     }
+
+    pub fn num_vbuckets(mut self, num_vbuckets: u16) -> Self {
+        self.num_vbuckets = Some(num_vbuckets);
+        self
+    }
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
@@ -143,6 +149,7 @@ impl From<BucketSettingsJson> for BucketDef {
                 replica_index: settings.replica_index,
                 bucket_type: settings.bucket_type,
                 storage_backend: settings.storage_backend,
+                num_vbuckets: settings.num_vbuckets,
             },
         }
     }
@@ -411,5 +418,8 @@ pub(crate) fn encode_bucket_settings(serializer: &mut Serializer<String>, opts: 
     }
     if let Some(storage_backend) = &opts.storage_backend {
         serializer.append_pair("storageBackend", storage_backend.to_string().as_str());
+    }
+    if let Some(num_vbuckets) = opts.num_vbuckets {
+        serializer.append_pair("numVBuckets", num_vbuckets.to_string().as_str());
     }
 }

--- a/sdk/couchbase-core/src/mgmtx/bucket_settings_json.rs
+++ b/sdk/couchbase-core/src/mgmtx/bucket_settings_json.rs
@@ -58,6 +58,8 @@ pub struct BucketSettingsJson {
     pub history_retention_bytes: Option<u64>,
     #[serde(default, rename = "historyRetentionSeconds")]
     pub history_retention_seconds: Option<u32>,
+    #[serde(default, rename = "numVBuckets")]
+    pub num_vbuckets: Option<u16>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/sdk/couchbase/src/management/buckets/bucket_settings.rs
+++ b/sdk/couchbase/src/management/buckets/bucket_settings.rs
@@ -20,6 +20,7 @@ pub struct BucketSettings {
     pub replica_indexes: Option<bool>,
     pub bucket_type: Option<BucketType>,
     pub storage_backend: Option<StorageBackend>,
+    pub num_vbuckets: Option<u16>,
 }
 
 impl BucketSettings {
@@ -40,6 +41,7 @@ impl BucketSettings {
             replica_indexes: None,
             bucket_type: None,
             storage_backend: None,
+            num_vbuckets: None,
         }
     }
 
@@ -119,6 +121,11 @@ impl BucketSettings {
 
     pub fn storage_backend(mut self, storage_backend: impl Into<StorageBackend>) -> Self {
         self.storage_backend = Some(storage_backend.into());
+        self
+    }
+
+    pub fn num_vbuckets(mut self, num_vbuckets: u16) -> Self {
+        self.num_vbuckets = Some(num_vbuckets);
         self
     }
 }
@@ -419,6 +426,7 @@ impl From<BucketDef> for BucketSettings {
             replica_indexes: value.bucket_settings.replica_index,
             bucket_type: value.bucket_settings.bucket_type.map(|v| v.into()),
             storage_backend: value.bucket_settings.storage_backend.map(|v| v.into()),
+            num_vbuckets: value.bucket_settings.num_vbuckets,
         }
     }
 }


### PR DESCRIPTION
… bucket

Motivation
==========
ns_server has added support for Magma buckets with 128 vBuckets, in addition to the existing configuration with 1024 vBuckets. We need to be able to specify the number of vBuckets that should be used in the SDK's bucket management API.

Change
=======
Add NumVBuckets to BucketSettings