### PR TITLE
RSCBC-79: Revisit all enums

### DIFF
--- a/sdk/couchbase-core/src/memdx/auth_mechanism.rs
+++ b/sdk/couchbase-core/src/memdx/auth_mechanism.rs
@@ -1,6 +1,7 @@
 use crate::memdx::error::Error;
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
 pub enum AuthMechanism {
     Plain,
     ScramSha1,

--- a/sdk/couchbase-core/src/memdx/datatype.rs
+++ b/sdk/couchbase-core/src/memdx/datatype.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum DataTypeFlag {
     None,
     Json,

--- a/sdk/couchbase-core/src/memdx/durability_level.rs
+++ b/sdk/couchbase-core/src/memdx/durability_level.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::time::Duration;
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub struct DurabilityLevel(InnerDurabilityLevel);
 
 impl DurabilityLevel {
@@ -12,10 +13,6 @@ impl DurabilityLevel {
 
     pub const PERSIST_TO_MAJORITY: DurabilityLevel =
         DurabilityLevel(InnerDurabilityLevel::PersistToMajority);
-
-    pub(crate) fn other(val: u8) -> DurabilityLevel {
-        DurabilityLevel(InnerDurabilityLevel::Other(val))
-    }
 }
 
 impl Display for DurabilityLevel {
@@ -54,7 +51,7 @@ impl From<u8> for DurabilityLevel {
             1 => DurabilityLevel::MAJORITY,
             2 => DurabilityLevel::MAJORITY_AND_PERSIST_ACTIVE,
             3 => DurabilityLevel::PERSIST_TO_MAJORITY,
-            _ => DurabilityLevel::other(data),
+            _ => DurabilityLevel(InnerDurabilityLevel::Other(data)),
         }
     }
 }

--- a/sdk/couchbase-core/src/memdx/ext_frame_code.rs
+++ b/sdk/couchbase-core/src/memdx/ext_frame_code.rs
@@ -1,4 +1,5 @@
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
 pub enum ExtReqFrameCode {
     Barrier,
     Durability,
@@ -28,6 +29,7 @@ impl From<ExtReqFrameCode> for u16 {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
 pub enum ExtResFrameCode {
     ServerDuration,
     ReadUnits,

--- a/sdk/couchbase-core/src/memdx/hello_feature.rs
+++ b/sdk/couchbase-core/src/memdx/hello_feature.rs
@@ -1,4 +1,5 @@
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
 pub enum HelloFeature {
     DataType,
     Tls,

--- a/sdk/couchbase-core/src/memdx/magic.rs
+++ b/sdk/couchbase-core/src/memdx/magic.rs
@@ -3,6 +3,7 @@ use std::fmt::{Debug, Display};
 use crate::memdx::error::Error;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Magic {
     Req,
     Res,

--- a/sdk/couchbase-core/src/memdx/opcode.rs
+++ b/sdk/couchbase-core/src/memdx/opcode.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 use crate::memdx::error::Error;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum OpCode {
     Get,
     Set,

--- a/sdk/couchbase-core/src/queryx/ensure_index_helper.rs
+++ b/sdk/couchbase-core/src/queryx/ensure_index_helper.rs
@@ -20,6 +20,7 @@ pub struct EnsureIndexHelper<'a> {
 }
 
 #[derive(Copy, Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DesiredState {
     Created,
     Deleted,

--- a/sdk/couchbase-core/src/queryx/query_result.rs
+++ b/sdk/couchbase-core/src/queryx/query_result.rs
@@ -6,6 +6,7 @@ use serde_json::value::RawValue;
 
 #[derive(Debug, Clone, Copy, Deserialize, Ord, PartialOrd, Eq, PartialEq, Hash)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Status {
     Running,
     Success,

--- a/sdk/couchbase-core/src/searchx/ensure_index_helper.rs
+++ b/sdk/couchbase-core/src/searchx/ensure_index_helper.rs
@@ -25,6 +25,7 @@ pub struct EnsureIndexHelper<'a> {
 }
 
 #[derive(Copy, Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DesiredState {
     Created,
     Deleted,

--- a/sdk/couchbase-core/src/service_type.rs
+++ b/sdk/couchbase-core/src/service_type.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 pub struct ServiceType(InnerServiceType);
 
 #[derive(Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Serialize)]
@@ -21,10 +22,6 @@ impl ServiceType {
     pub const QUERY: ServiceType = ServiceType(InnerServiceType::Query);
     pub const SEARCH: ServiceType = ServiceType(InnerServiceType::Search);
     pub const EVENTING: ServiceType = ServiceType(InnerServiceType::Eventing);
-
-    pub(crate) fn other(val: String) -> ServiceType {
-        ServiceType(InnerServiceType::Other(val))
-    }
 }
 
 impl Display for ServiceType {

--- a/sdk/couchbase/src/durability_level.rs
+++ b/sdk/couchbase/src/durability_level.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub struct DurabilityLevel(InnerDurabilityLevel);
 
 impl DurabilityLevel {
@@ -13,10 +14,6 @@ impl DurabilityLevel {
 
     pub const PERSIST_TO_MAJORITY: DurabilityLevel =
         DurabilityLevel(InnerDurabilityLevel::PersistToMajority);
-
-    pub(crate) fn other(val: String) -> DurabilityLevel {
-        DurabilityLevel(InnerDurabilityLevel::Other(val))
-    }
 }
 
 impl Display for DurabilityLevel {
@@ -82,7 +79,7 @@ impl From<couchbase_core::mgmtx::bucket_settings::DurabilityLevel> for Durabilit
             couchbase_core::mgmtx::bucket_settings::DurabilityLevel::MAJORITY => DurabilityLevel::MAJORITY,
             couchbase_core::mgmtx::bucket_settings::DurabilityLevel::MAJORITY_AND_PERSIST_ACTIVE => DurabilityLevel::MAJORITY_AND_PERSIST_ACTIVE,
             couchbase_core::mgmtx::bucket_settings::DurabilityLevel::PERSIST_TO_MAJORITY => DurabilityLevel::PERSIST_TO_MAJORITY,
-            _ => DurabilityLevel::other(value.to_string()),
+            _ => DurabilityLevel(InnerDurabilityLevel::Other(value.to_string())),
         }
     }
 }

--- a/sdk/couchbase/src/error.rs
+++ b/sdk/couchbase/src/error.rs
@@ -135,6 +135,7 @@ impl Display for Error {
 impl StdError for Error {}
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub enum ErrorKind {
     OtherFailure(String),
     ServerTimeout,

--- a/sdk/couchbase/src/management/buckets/bucket_settings.rs
+++ b/sdk/couchbase/src/management/buckets/bucket_settings.rs
@@ -137,10 +137,6 @@ impl BucketType {
     pub const COUCHBASE: BucketType = BucketType(InnerBucketType::Couchbase);
 
     pub const EPHEMERAL: BucketType = BucketType(InnerBucketType::Ephemeral);
-
-    pub(crate) fn unknown(val: String) -> BucketType {
-        BucketType(InnerBucketType::Unknown(val))
-    }
 }
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -164,10 +160,6 @@ impl EvictionPolicyType {
 
     pub const NO_EVICTION: EvictionPolicyType =
         EvictionPolicyType(InnerEvictionPolicyType::NoEviction);
-
-    pub(crate) fn unknown(val: String) -> EvictionPolicyType {
-        EvictionPolicyType(InnerEvictionPolicyType::Unknown(val))
-    }
 }
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -188,10 +180,6 @@ impl CompressionMode {
     pub const PASSIVE: CompressionMode = CompressionMode(InnerCompressionMode::Passive);
 
     pub const ACTIVE: CompressionMode = CompressionMode(InnerCompressionMode::Active);
-
-    pub(crate) fn unknown(val: String) -> CompressionMode {
-        CompressionMode(InnerCompressionMode::Unknown(val))
-    }
 }
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -214,10 +202,6 @@ impl ConflictResolutionType {
 
     pub const CUSTOM: ConflictResolutionType =
         ConflictResolutionType(InnerConflictResolutionType::Custom);
-
-    pub(crate) fn unknown(val: String) -> ConflictResolutionType {
-        ConflictResolutionType(InnerConflictResolutionType::Unknown(val))
-    }
 }
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -235,10 +219,6 @@ impl StorageBackend {
     pub const COUCHSTORE: StorageBackend = StorageBackend(InnerStorageBackend::Couchstore);
 
     pub const MAGMA: StorageBackend = StorageBackend(InnerStorageBackend::Magma);
-
-    pub(crate) fn unknown(val: String) -> StorageBackend {
-        StorageBackend(InnerStorageBackend::Unknown(val))
-    }
 }
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -329,7 +309,7 @@ impl From<couchbase_core::mgmtx::bucket_settings::BucketType> for BucketType {
         match value {
             couchbase_core::mgmtx::bucket_settings::BucketType::COUCHBASE => BucketType::COUCHBASE,
             couchbase_core::mgmtx::bucket_settings::BucketType::EPHEMERAL => BucketType::EPHEMERAL,
-            _ => BucketType::unknown(value.to_string()),
+            _ => BucketType(InnerBucketType::Unknown(value.to_string())),
         }
     }
 }
@@ -349,7 +329,7 @@ impl From<couchbase_core::mgmtx::bucket_settings::EvictionPolicyType> for Evicti
             couchbase_core::mgmtx::bucket_settings::EvictionPolicyType::NO_EVICTION => {
                 EvictionPolicyType::NO_EVICTION
             }
-            _ => EvictionPolicyType::unknown(value.to_string()),
+            _ => EvictionPolicyType(InnerEvictionPolicyType::Unknown(value.to_string())),
         }
     }
 }
@@ -364,7 +344,7 @@ impl From<couchbase_core::mgmtx::bucket_settings::CompressionMode> for Compressi
             couchbase_core::mgmtx::bucket_settings::CompressionMode::ACTIVE => {
                 CompressionMode::ACTIVE
             }
-            _ => CompressionMode::unknown(value.to_string()),
+            _ => CompressionMode(InnerCompressionMode::Unknown(value.to_string())),
         }
     }
 }
@@ -383,7 +363,7 @@ impl From<couchbase_core::mgmtx::bucket_settings::ConflictResolutionType>
             couchbase_core::mgmtx::bucket_settings::ConflictResolutionType::CUSTOM => {
                 ConflictResolutionType::CUSTOM
             }
-            _ => ConflictResolutionType::unknown(value.to_string()),
+            _ => ConflictResolutionType(InnerConflictResolutionType::Unknown(value.to_string())),
         }
     }
 }
@@ -395,7 +375,7 @@ impl From<couchbase_core::mgmtx::bucket_settings::StorageBackend> for StorageBac
                 StorageBackend::COUCHSTORE
             }
             couchbase_core::mgmtx::bucket_settings::StorageBackend::MAGMA => StorageBackend::MAGMA,
-            _ => StorageBackend::unknown(value.to_string()),
+            _ => StorageBackend(InnerStorageBackend::Unknown(value.to_string())),
         }
     }
 }

--- a/sdk/couchbase/src/options/query_options.rs
+++ b/sdk/couchbase/src/options/query_options.rs
@@ -27,7 +27,6 @@ impl From<ScanConsistency> for queryx::query_options::ScanConsistency {
 }
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-#[non_exhaustive]
 pub enum ReplicaLevel {
     On,
     Off,

--- a/sdk/couchbase/src/results/query_results.rs
+++ b/sdk/couchbase/src/results/query_results.rs
@@ -29,6 +29,7 @@ impl From<queryx::query_result::Warning> for QueryWarning {
 }
 
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub enum QueryStatus {
     Running,
     Success,
@@ -54,7 +55,7 @@ impl From<queryx::query_result::Status> for QueryStatus {
             queryx::query_result::Status::Closed => Self::Closed,
             queryx::query_result::Status::Fatal => Self::Fatal,
             queryx::query_result::Status::Aborted => Self::Aborted,
-            queryx::query_result::Status::Unknown => Self::Unknown,
+            _ => Self::Unknown,
         }
     }
 }

--- a/sdk/couchbase/src/results/search_results.rs
+++ b/sdk/couchbase/src/results/search_results.rs
@@ -107,6 +107,7 @@ impl<'a> From<&'a searchx::search_result::DateRangeFacetResult> for DateRangeFac
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
+#[non_exhaustive]
 pub enum SearchFacetResultType<'a> {
     TermFacets(Vec<TermFacetResult<'a>>),
     NumericRangeFacets(Vec<NumericRangeFacetResult<'a>>),

--- a/sdk/couchbase/src/search/queries.rs
+++ b/sdk/couchbase/src/search/queries.rs
@@ -710,6 +710,7 @@ impl GeoPolygonQuery {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Query {
     Match(MatchQuery),
     MatchPhrase(MatchPhraseQuery),

--- a/sdk/couchbase/src/search/vector.rs
+++ b/sdk/couchbase/src/search/vector.rs
@@ -43,6 +43,7 @@ impl VectorSearchOptions {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum VectorQueryCombination {
     And,
     Or,

--- a/sdk/couchbase/src/service_type.rs
+++ b/sdk/couchbase/src/service_type.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 pub struct ServiceType(InnerServiceType);
 
 #[derive(Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Serialize)]
@@ -20,10 +21,6 @@ impl ServiceType {
     pub const QUERY: ServiceType = ServiceType(InnerServiceType::Query);
     pub const SEARCH: ServiceType = ServiceType(InnerServiceType::Search);
     pub const EVENTING: ServiceType = ServiceType(InnerServiceType::Eventing);
-
-    pub(crate) fn other(val: String) -> ServiceType {
-        ServiceType(InnerServiceType::Other(val))
-    }
 }
 
 impl Display for ServiceType {
@@ -68,7 +65,7 @@ impl From<ServiceType> for couchbase_core::service_type::ServiceType {
             ServiceType::QUERY => couchbase_core::service_type::ServiceType::QUERY,
             ServiceType::SEARCH => couchbase_core::service_type::ServiceType::SEARCH,
             ServiceType::EVENTING => couchbase_core::service_type::ServiceType::EVENTING,
-            ServiceType(InnerServiceType::Other(_val)) => unreachable!(), // This isn't possible, users can't create other, and we just don't.
+            _ => unreachable!(), // This isn't possible, users can't create other, and we just don't.
         }
     }
 }

--- a/sdk/couchbase/src/transcoding/mod.rs
+++ b/sdk/couchbase/src/transcoding/mod.rs
@@ -5,6 +5,7 @@ use serde::de::DeserializeOwned;
 use serde::{Serialize, Serializer};
 
 #[derive(Debug, PartialEq, Clone, Hash, Ord, PartialOrd, Eq)]
+#[non_exhaustive]
 pub enum DataType {
     Unknown,
     Json,

--- a/sdk/couchbase/tests/search.rs
+++ b/sdk/couchbase/tests/search.rs
@@ -213,6 +213,7 @@ fn test_search_basic() {
             SearchFacetResultType::DateRangeFacets(_) => {
                 panic!("expected term facet")
             }
+            _ => panic!("unexpected facet type"),
         }
 
         let dates = facets.get(&String::from("date")).unwrap();
@@ -236,6 +237,7 @@ fn test_search_basic() {
                 assert_eq!("2000-07-22T20:00:20+00:00", range.start.to_rfc3339());
                 assert_eq!("2020-07-22T20:00:20+00:00", range.end.to_rfc3339());
             }
+            _ => panic!("unexpected facet type"),
         }
 
         let numeric = facets.get(&String::from("numeric")).unwrap();
@@ -259,6 +261,7 @@ fn test_search_basic() {
             SearchFacetResultType::DateRangeFacets(_) => {
                 panic!("expected numeric range facet")
             }
+            _ => panic!("unexpected facet type"),
         }
     })
 }


### PR DESCRIPTION
Motivation
----------
We need to ensure that we're using newtype pattern for enums that the server really owns. We also need to ensure that we can further expand enums that we may need to in the future.