### PR TITLE
Fix mismatched-lifetime-syntaxes lint warnings

### DIFF
--- a/sdk/couchbase-core/src/memdx/error.rs
+++ b/sdk/couchbase-core/src/memdx/error.rs
@@ -120,7 +120,7 @@ impl Error {
         } else if let ErrorKind::Resource(e) = inner_kind {
             Some(e.cause.opaque)
         } else if let ErrorKind::Dispatch { opaque, .. } = inner_kind {
-            return Some(*opaque);
+            Some(*opaque)
         } else {
             None
         }

--- a/sdk/couchbase/src/collection_ds.rs
+++ b/sdk/couchbase/src/collection_ds.rs
@@ -21,7 +21,7 @@ impl Collection {
         &self,
         id: impl Into<String>,
         options: impl Into<Option<CouchbaseListOptions>>,
-    ) -> CouchbaseList {
+    ) -> CouchbaseList<'_> {
         CouchbaseList {
             collection: self,
             id: id.into(),
@@ -33,7 +33,7 @@ impl Collection {
         &self,
         id: impl Into<String>,
         options: impl Into<Option<CouchbaseMapOptions>>,
-    ) -> CouchbaseMap {
+    ) -> CouchbaseMap<'_> {
         CouchbaseMap {
             collection: self,
             id: id.into(),
@@ -45,7 +45,7 @@ impl Collection {
         &self,
         id: impl Into<String>,
         options: impl Into<Option<CouchbaseSetOptions>>,
-    ) -> CouchbaseSet {
+    ) -> CouchbaseSet<'_> {
         CouchbaseSet {
             collection: self,
             id: id.into(),
@@ -57,7 +57,7 @@ impl Collection {
         &self,
         id: impl Into<String>,
         options: impl Into<Option<CouchbaseQueueOptions>>,
-    ) -> CouchbaseQueue {
+    ) -> CouchbaseQueue<'_> {
         CouchbaseQueue {
             collection: self,
             id: id.into(),

--- a/sdk/couchbase/src/results/query_results.rs
+++ b/sdk/couchbase/src/results/query_results.rs
@@ -146,7 +146,7 @@ impl<V: DeserializeOwned> Stream for QueryRows<'_, V> {
 }
 
 impl QueryResult {
-    pub async fn metadata(&self) -> error::Result<QueryMetaData> {
+    pub async fn metadata(&self) -> error::Result<QueryMetaData<'_>> {
         Ok(self.wrapped.metadata()?.into())
     }
 

--- a/sdk/couchbase/src/results/search_results.rs
+++ b/sdk/couchbase/src/results/search_results.rs
@@ -261,7 +261,7 @@ impl Stream for SearchRows<'_> {
 }
 
 impl SearchResult {
-    pub fn metadata(&self) -> error::Result<SearchMetaData> {
+    pub fn metadata(&self) -> error::Result<SearchMetaData<'_>> {
         Ok(self.wrapped.metadata()?.into())
     }
 
@@ -271,7 +271,7 @@ impl SearchResult {
         }
     }
 
-    pub fn facets(&self) -> error::Result<HashMap<&String, SearchFacetResult>> {
+    pub fn facets(&self) -> error::Result<HashMap<&String, SearchFacetResult<'_>>> {
         let mut facets = HashMap::new();
         for (name, facet) in self.wrapped.facets()? {
             if let Some(facet_terms) = &facet.terms {


### PR DESCRIPTION
Rust 1.89 introduced mismatched-lifetime-syntaxes which caused a number of warnings/build issues.