### PR TITLE
RSCBC-111: Rework error source fields

### DIFF
--- a/sdk/couchbase-core/src/httpx/client.rs
+++ b/sdk/couchbase-core/src/httpx/client.rs
@@ -10,6 +10,7 @@ use base64::Engine;
 use http::header::{CONTENT_TYPE, USER_AGENT};
 use log::trace;
 use reqwest::redirect::Policy;
+use std::error::Error as StdError;
 use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
@@ -183,12 +184,17 @@ impl Client for ReqwestClient {
                 Response::from(response)
             }),
             Err(err) => {
-                trace!(
+                let mut msg = format!(
                     "Received error on {}. Request id={}. Err: {}",
-                    &self.client_id,
-                    &id,
-                    &err,
+                    &self.client_id, &id, &err,
                 );
+
+                if let Some(source) = err.source() {
+                    msg = format!("{msg}. Source: {source}");
+                }
+
+                trace!("{msg}");
+
                 if err.is_connect() {
                     Err(Error::new_connection_error(err.to_string()))
                 } else {

--- a/sdk/couchbase-core/src/mgmtx/error.rs
+++ b/sdk/couchbase-core/src/mgmtx/error.rs
@@ -15,21 +15,13 @@ impl Display for Error {
     }
 }
 
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        self.inner
-            .source
-            .as_ref()
-            .map(|cause| &**cause as &(dyn StdError + 'static))
-    }
-}
+impl StdError for Error {}
 
 impl Error {
     pub(crate) fn new_message_error(msg: impl Into<String>) -> Self {
         Self {
             inner: Box::new(ErrorImpl {
                 kind: ErrorKind::Message(msg.into()),
-                source: None,
             }),
         }
     }
@@ -44,14 +36,8 @@ impl Error {
                     msg: msg.into(),
                     arg: arg.into(),
                 },
-                source: None,
             }),
         }
-    }
-
-    pub(crate) fn with<C: Into<Source>>(mut self, source: C) -> Error {
-        self.inner.source = Some(source.into());
-        self
     }
 
     pub fn kind(&self) -> &ErrorKind {
@@ -59,12 +45,9 @@ impl Error {
     }
 }
 
-type Source = Box<dyn StdError + Send + Sync>;
-
 #[derive(Debug)]
 pub struct ErrorImpl {
     pub kind: ErrorKind,
-    source: Option<Source>,
 }
 
 impl PartialEq for ErrorImpl {
@@ -277,7 +260,6 @@ where
         Self {
             inner: Box::new(ErrorImpl {
                 kind: ErrorKind::from(err),
-                source: None,
             }),
         }
     }
@@ -288,7 +270,6 @@ impl From<ServerError> for Error {
         Self {
             inner: Box::new(ErrorImpl {
                 kind: ErrorKind::Server(value),
-                source: None,
             }),
         }
     }
@@ -299,7 +280,6 @@ impl From<ResourceError> for Error {
         Self {
             inner: Box::new(ErrorImpl {
                 kind: ErrorKind::Resource(value),
-                source: None,
             }),
         }
     }

--- a/sdk/couchbase-core/src/mgmtx/manifest_helper.rs
+++ b/sdk/couchbase-core/src/mgmtx/manifest_helper.rs
@@ -51,8 +51,9 @@ impl<'a> EnsureManifestHelper<'a> {
         })
         .await?;
 
-        let manifest_uid = u64::from_str_radix(&resp.uid, 16)
-            .map_err(|e| error::Error::new_message_error("Failed to parse manifest uid").with(e))?;
+        let manifest_uid = u64::from_str_radix(&resp.uid, 16).map_err(|e| {
+            error::Error::new_message_error(format!("failed to parse manifest uid: {e}"))
+        })?;
 
         if manifest_uid < self.manifest_uid {
             return Ok(false);

--- a/sdk/couchbase-core/src/mgmtx/mgmt.rs
+++ b/sdk/couchbase-core/src/mgmtx/mgmt.rs
@@ -86,7 +86,7 @@ impl<C: Client> Management<C> {
         self.http_client
             .execute(req)
             .await
-            .map_err(|e| error::Error::new_message_error("could not execute request").with(e))
+            .map_err(|e| error::Error::new_message_error(format!("could not execute request: {e}")))
     }
 
     pub(crate) async fn decode_common_error(
@@ -100,14 +100,18 @@ impl<C: Client> Management<C> {
         let body = match response.bytes().await {
             Ok(b) => b,
             Err(e) => {
-                return error::Error::new_message_error("could not parse response body").with(e)
+                return error::Error::new_message_error(format!(
+                    "could not parse response body: {e}"
+                ))
             }
         };
 
         let body_str = match String::from_utf8(body.to_vec()) {
             Ok(s) => s.to_lowercase(),
             Err(e) => {
-                return error::Error::new_message_error("could not parse error response").with(e)
+                return error::Error::new_message_error(format!(
+                    "could not parse error response: {e}"
+                ))
             }
         };
 
@@ -246,10 +250,10 @@ pub(crate) async fn parse_response_json<T: DeserializeOwned>(resp: Response) -> 
     let body = resp
         .bytes()
         .await
-        .map_err(|e| error::Error::new_message_error("could not read response").with(e))?;
+        .map_err(|e| error::Error::new_message_error(format!("could not read response: {e}")))?;
 
     serde_json::from_slice(&body)
-        .map_err(|e| error::Error::new_message_error("could not parse response").with(e))
+        .map_err(|e| error::Error::new_message_error(format!("could not parse response: {e}")))
 }
 
 #[derive(Deserialize)]

--- a/sdk/couchbase-core/src/mgmtx/mgmt_collection.rs
+++ b/sdk/couchbase-core/src/mgmtx/mgmt_collection.rs
@@ -33,7 +33,7 @@ impl<C: Client> Management<C> {
             )
             .await
             .map_err(|e| {
-                error::Error::new_message_error("could not get collections manifest").with(e)
+                error::Error::new_message_error(format!("could not get collections manifest: {e}"))
             })?;
 
         if resp.status() != 200 {

--- a/sdk/couchbase-core/src/queryx/query.rs
+++ b/sdk/couchbase-core/src/queryx/query.rs
@@ -135,10 +135,11 @@ impl<C: Client> Query<C> {
         {
             Ok(r) => r,
             Err(e) => {
-                return Err(
-                    Error::new_http_error(&self.endpoint, statement, client_context_id)
-                        .with(Arc::new(e)),
-                );
+                return Err(Error::new_http_error(
+                    format!("{}: {}", &self.endpoint, e),
+                    statement,
+                    client_context_id,
+                ));
             }
         };
 
@@ -531,7 +532,11 @@ impl<C: Client> Query<C> {
         {
             Ok(r) => r,
             Err(e) => {
-                return Err(Error::new_http_error(&self.endpoint, None, None).with(Arc::new(e)));
+                return Err(Error::new_http_error(
+                    format!("{}: {}", &self.endpoint, e),
+                    None,
+                    None,
+                ));
             }
         };
 

--- a/sdk/couchbase-core/src/searchx/search.rs
+++ b/sdk/couchbase-core/src/searchx/search.rs
@@ -122,7 +122,7 @@ impl<C: Client> Search<C> {
                 Some(Bytes::from(body)),
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         SearchRespReader::new(res, &opts.index_name, &self.endpoint).await
     }
@@ -148,7 +148,7 @@ impl<C: Client> Search<C> {
                 Some(Bytes::from(body)),
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         if res.status() != 200 {
             return Err(
@@ -176,7 +176,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(
@@ -204,7 +204,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(
@@ -217,10 +217,9 @@ impl<C: Client> Search<C> {
 
         let index: SearchIndexResponseJson = parse_response_json(res).await.map_err(|e| {
             error::Error::new_message_error(
-                "failed to parse index json",
+                format!("failed to parse index json: {e}"),
                 Some(self.endpoint.clone()),
             )
-            .with(Arc::new(e))
         })?;
 
         Ok(index.index_def.into())
@@ -243,7 +242,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(res, "".to_string(), self.endpoint.clone()).await);
@@ -251,10 +250,9 @@ impl<C: Client> Search<C> {
 
         let index: SearchIndexesResponseJson = parse_response_json(res).await.map_err(|e| {
             error::Error::new_message_error(
-                "failed to parse index json",
+                format!("failed to parse index json: {e}"),
                 Some(self.endpoint.clone()),
             )
-            .with(Arc::new(e))
         })?;
 
         Ok(index
@@ -283,7 +281,7 @@ impl<C: Client> Search<C> {
                 Some(body),
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(
@@ -296,10 +294,9 @@ impl<C: Client> Search<C> {
 
         let analysis: DocumentAnalysisJson = parse_response_json(res).await.map_err(|e| {
             error::Error::new_message_error(
-                "failed to parse document analysis",
+                format!("failed to parse document analysis: {e}"),
                 Some(self.endpoint.clone()),
             )
-            .with(Arc::new(e))
         })?;
 
         Ok(analysis.into())
@@ -335,7 +332,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(
@@ -348,10 +345,9 @@ impl<C: Client> Search<C> {
 
         let count: IndexedDocumentsJson = parse_response_json(res).await.map_err(|e| {
             error::Error::new_message_error(
-                "failed to parse indexed count",
+                format!("failed to parse indexed count: {e}"),
                 Some(self.endpoint.clone()),
             )
-            .with(Arc::new(e))
         })?;
 
         Ok(count.count)
@@ -437,7 +433,7 @@ impl<C: Client> Search<C> {
         {
             Ok(r) => r,
             Err(e) => {
-                return Err(Error::new_http_error(&self.endpoint).with(Arc::new(e)));
+                return Err(Error::new_http_error(format!("{}: {}", &self.endpoint, e)));
             }
         };
 
@@ -493,7 +489,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         if res.status() != 200 {
             return Err(
@@ -518,7 +514,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(&self.endpoint).with(Arc::new(e)))?;
+            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(res, "".to_string(), self.endpoint.clone()).await);
@@ -559,7 +555,7 @@ pub(crate) async fn decode_response_error(
     let body = match response.bytes().await {
         Ok(b) => b,
         Err(e) => {
-            return error::Error::new_http_error(endpoint).with(Arc::new(e));
+            return error::Error::new_http_error(format!("{endpoint}: {e}"));
         }
     };
 

--- a/sdk/couchbase-core/src/searchx/search_respreader.rs
+++ b/sdk/couchbase-core/src/searchx/search_respreader.rs
@@ -61,9 +61,8 @@ impl Stream for SearchRespReader {
                 Poll::Ready(None)
             }
             Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(error::Error::new_http_error(
-                &this.endpoint,
-            )
-            .with(Arc::new(e))))),
+                format!("{}: {}", &this.endpoint, e),
+            )))),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }
@@ -85,7 +84,7 @@ impl SearchRespReader {
                 Ok(b) => b,
                 Err(e) => {
                     debug!("Failed to read response body on error {e}");
-                    return Err(error::Error::new_http_error(endpoint).with(Arc::new(e)));
+                    return Err(error::Error::new_http_error(format!("{endpoint}: {e}")));
                 }
             };
 
@@ -115,7 +114,7 @@ impl SearchRespReader {
         match streamer.read_prelude().await {
             Ok(_) => {}
             Err(e) => {
-                return Err(error::Error::new_http_error(endpoint).with(Arc::new(e)));
+                return Err(error::Error::new_http_error(format!("{endpoint}: {e}")));
             }
         };
 
@@ -125,7 +124,7 @@ impl SearchRespReader {
             epilog = match streamer.epilog() {
                 Ok(epilog) => Some(epilog),
                 Err(e) => {
-                    return Err(error::Error::new_http_error(endpoint).with(Arc::new(e)));
+                    return Err(error::Error::new_http_error(format!("{endpoint}: {e}")));
                 }
             };
         }

--- a/sdk/couchbase/src/error.rs
+++ b/sdk/couchbase/src/error.rs
@@ -76,6 +76,10 @@ impl Error {
             collection_name,
         );
 
+        if let Some(source) = e.source() {
+            extended_context = extended_context.with_source_message(source.to_string());
+        }
+
         if let Some(xerror) = e.context() {
             if let Some(parsed) = ServerError::parse_context(xerror) {
                 if let Some(text) = parsed.text {

--- a/sdk/couchbase/src/error_context.rs
+++ b/sdk/couchbase/src/error_context.rs
@@ -133,6 +133,7 @@ pub(crate) struct KeyValueErrorContext {
     pub(crate) error_desc: Option<String>,
     pub(crate) xcontent: Option<String>,
     pub(crate) xref: Option<String>,
+    pub(crate) source_message: Option<String>,
 }
 
 impl KeyValueErrorContext {
@@ -157,6 +158,7 @@ impl KeyValueErrorContext {
             error_desc: None,
             xcontent: None,
             xref: None,
+            source_message: None,
         }
     }
 
@@ -177,6 +179,11 @@ impl KeyValueErrorContext {
 
     pub fn with_xref(mut self, xref: String) -> Self {
         self.xref = Some(xref);
+        self
+    }
+
+    pub fn with_source_message(mut self, source_message: String) -> Self {
+        self.source_message = Some(source_message);
         self
     }
 }
@@ -209,6 +216,10 @@ impl Serialize for KeyValueErrorContext {
 
         if let Some(ref xref) = self.xref {
             state.serialize_field("xref", xref)?;
+        }
+
+        if let Some(ref source_message) = self.source_message {
+            state.serialize_field("sourceMessage", source_message)?;
         }
 
         state.end()


### PR DESCRIPTION
Motivation
----------
Source is designed to allow users to access underlying platform errors from our error types. In the case of http based errors we don't actually want to do this as it'll leak implementation detail.

Changes
-------
Remove source from error types for services utilising http. Update log messages for memdx errors to include source messages. Update public API error to include any source in the error message.