### PR TITLE
RSCBC-117: Expose internal constructor for MutationToken

### DIFF
--- a/sdk/couchbase/Cargo.toml
+++ b/sdk/couchbase/Cargo.toml
@@ -41,6 +41,7 @@ rustls-tls = ["dep:tokio-rustls", "couchbase-core/rustls-tls", "dep:rustls-pemfi
 native-tls = ["dep:tokio-native-tls", "couchbase-core/native-tls"]
 uncommitted = []
 volatile = []
+internal = []
 
 [lints.rust]
 # This is temporary whilst we build out the root modules.

--- a/sdk/couchbase/src/mutation_state.rs
+++ b/sdk/couchbase/src/mutation_state.rs
@@ -20,6 +20,14 @@ impl MutationToken {
         Self { token, bucket_name }
     }
 
+    #[cfg(feature = "internal")]
+    pub fn from_parts(vbid: u16, vbuuid: u64, seqno: u64, bucket_name: String) -> Self {
+        Self {
+            token: couchbase_core::mutationtoken::MutationToken::new(vbid, vbuuid, seqno),
+            bucket_name,
+        }
+    }
+
     pub fn partition_id(&self) -> u16 {
         self.token.vbid()
     }


### PR DESCRIPTION
Motivation
-
Expose constructor for mutation tokens for FIT testing purposes

Changes
-
- Added internal feature
- Exposed internal mutation token constructor
