### PR TITLE
RSCBC-134: VectorSearch num_candidates should set a default

### DIFF
--- a/sdk/couchbase-core/src/searchx/query_options.rs
+++ b/sdk/couchbase-core/src/searchx/query_options.rs
@@ -146,8 +146,7 @@ pub struct KnnQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boost: Option<f32>,
     pub field: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub k: Option<i64>,
+    pub k: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vector: Option<Vec<f32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -157,11 +156,11 @@ pub struct KnnQuery {
 }
 
 impl KnnQuery {
-    pub fn new(field: impl Into<String>) -> Self {
+    pub fn new(field: impl Into<String>, k: impl Into<i64>) -> Self {
         Self {
             boost: None,
             field: field.into(),
-            k: None,
+            k: k.into(),
             vector: None,
             vector_base64: None,
             filter: None,
@@ -173,7 +172,7 @@ impl KnnQuery {
         self
     }
 
-    pub fn k(mut self, k: impl Into<Option<i64>>) -> Self {
+    pub fn k(mut self, k: impl Into<i64>) -> Self {
         self.k = k.into();
         self
     }

--- a/sdk/couchbase/src/search/vector.rs
+++ b/sdk/couchbase/src/search/vector.rs
@@ -62,10 +62,10 @@ impl From<VectorQueryCombination> for KnnOperator {
 #[derive(Debug, Clone)]
 pub struct VectorQuery {
     pub(crate) field_name: String,
+    pub(crate) num_candidates: u32,
     pub(crate) query: Option<Vec<f32>>,
     pub(crate) base64_query: Option<String>,
     pub(crate) boost: Option<f32>,
-    pub(crate) num_candidates: Option<u32>,
     pub(crate) prefilter: Option<Query>,
 }
 
@@ -76,7 +76,7 @@ impl VectorQuery {
             query: Some(vector_query),
             base64_query: None,
             boost: None,
-            num_candidates: None,
+            num_candidates: 3,
             prefilter: None,
         }
     }
@@ -90,7 +90,7 @@ impl VectorQuery {
             query: None,
             base64_query: Some(base_64_vector_query.into()),
             boost: None,
-            num_candidates: None,
+            num_candidates: 3,
             prefilter: None,
         }
     }
@@ -101,7 +101,7 @@ impl VectorQuery {
     }
 
     pub fn num_candidates(mut self, num_candidates: u32) -> Self {
-        self.num_candidates = Some(num_candidates);
+        self.num_candidates = num_candidates;
         self
     }
 
@@ -127,9 +127,8 @@ impl TryFrom<VectorQuery> for KnnQuery {
             ));
         }
 
-        Ok(KnnQuery::new(value.field_name)
+        Ok(KnnQuery::new(value.field_name, value.num_candidates)
             .boost(value.boost)
-            .k(value.num_candidates.map(|n| n as i64))
             .vector(value.query)
             .vector_base64(value.base64_query)
             .filter(value.prefilter.map(|q| q.into())))


### PR DESCRIPTION
Motivation
-----------
`k` has to be set in the search payload, and per RFC should default to 3

Changes
---------
Set num_candidates default to 3