### PR TITLE
RSCBC-143: Updates to ensure dropping cluster/agent closes resources

### DIFF
--- a/sdk/couchbase-core/src/configmanager.rs
+++ b/sdk/couchbase-core/src/configmanager.rs
@@ -41,7 +41,6 @@ pub(crate) struct ConfigManagerMemdOptions<M: KvClientManager> {
     pub polling_period: Duration,
     pub first_config: ParsedConfig,
     pub kv_client_manager: Arc<M>,
-    pub on_shutdown_rx: broadcast::Receiver<()>,
 }
 
 pub(crate) struct ConfigManagerMemd<M: KvClientManager> {
@@ -61,7 +60,6 @@ pub(crate) struct ConfigManagerMemdInner<M: KvClientManager> {
 
     on_new_config_tx: watch::Sender<ParsedConfig>,
 
-    on_shutdown_rx: broadcast::Receiver<()>,
     watcher_shutdown_tx: broadcast::Sender<()>,
 }
 
@@ -239,7 +237,7 @@ impl<M: KvClientManager + 'static> ConfigManagerMemdInner<M> {
                     }
                     Err(e) => {
                         if e == RecvError::Closed {
-                            debug!("Config watcher channel closed");
+                            debug!("Config watcher exited");
                             return;
                         } else {
                             warn!("Config watcher channel error: {e}");
@@ -294,7 +292,6 @@ impl<M: KvClientManager + 'static> ConfigManagerMemd<M> {
 
             on_new_config_tx,
 
-            on_shutdown_rx: opts.on_shutdown_rx,
             watcher_shutdown_tx,
         });
 

--- a/sdk/couchbase-core/src/configwatcher.rs
+++ b/sdk/couchbase-core/src/configwatcher.rs
@@ -186,7 +186,7 @@ where
         let inner = self.inner.clone();
         tokio::spawn(async move {
             inner.watch(on_shutdown_rx, on_new_config_tx).await;
-            debug!("config poll exit")
+            debug!("Config poller exited")
         });
 
         on_new_config_rx

--- a/sdk/couchbase-core/src/httpx/client.rs
+++ b/sdk/couchbase-core/src/httpx/client.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use http::header::{CONTENT_TYPE, USER_AGENT};
-use log::trace;
+use log::{debug, trace};
 use reqwest::redirect::Policy;
 use std::error::Error as StdError;
 use std::sync::Arc;
@@ -202,5 +202,11 @@ impl Client for ReqwestClient {
                 }
             }
         }
+    }
+}
+
+impl Drop for ReqwestClient {
+    fn drop(&mut self) {
+        debug!("Dropping HTTP Client {}", &self.client_id);
     }
 }

--- a/sdk/couchbase-core/src/kvclient.rs
+++ b/sdk/couchbase-core/src/kvclient.rs
@@ -64,6 +64,7 @@ pub(crate) type OnErrMapFetchedHandler = Arc<dyn Fn(&[u8]) + Send + Sync>;
 
 pub(crate) type UnsolicitedPacketSender = mpsc::UnboundedSender<ResponsePacket>;
 
+#[derive(Clone)]
 pub(crate) struct KvClientOptions {
     pub unsolicited_packet_tx: Option<UnsolicitedPacketSender>,
     pub orphan_handler: OrphanResponseHandler,

--- a/sdk/couchbase-core/src/ondemand_agentmanager.rs
+++ b/sdk/couchbase-core/src/ondemand_agentmanager.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
+use futures::executor::block_on;
 use log::debug;
 use tokio::sync::{Mutex, Notify};
 
@@ -19,15 +20,16 @@ use crate::tls_config::TlsConfig;
 
 pub struct OnDemandAgentManager {
     opts: OnDemandAgentManagerOptions,
-    cluster_agent: Agent,
-    fast_map: ArcSwap<HashMap<String, Agent>>,
-    slow_map: Mutex<HashMap<String, Agent>>,
+    // This is Arc so that we can provide a consistent API for handing out agents.
+    cluster_agent: Arc<Agent>,
+    fast_map: ArcSwap<HashMap<String, Weak<Agent>>>,
+    slow_map: Mutex<HashMap<String, Arc<Agent>>>,
     notif_map: Mutex<HashMap<String, Arc<Notify>>>,
 }
 
 impl OnDemandAgentManager {
     pub async fn new(opts: OnDemandAgentManagerOptions) -> error::Result<Self> {
-        let cluster_agent = Agent::new(opts.clone().into()).await?;
+        let cluster_agent = Arc::new(Agent::new(opts.clone().into()).await?);
 
         Ok(Self {
             opts,
@@ -38,26 +40,39 @@ impl OnDemandAgentManager {
         })
     }
 
-    pub fn get_cluster_agent(&self) -> &Agent {
-        &self.cluster_agent
+    pub fn get_cluster_agent(&self) -> Weak<Agent> {
+        Arc::downgrade(&self.cluster_agent)
     }
 
-    pub async fn get_bucket_agent(&self, bucket_name: impl Into<String>) -> error::Result<Agent> {
+    pub async fn get_bucket_agent(
+        &self,
+        bucket_name: impl Into<String>,
+    ) -> error::Result<Weak<Agent>> {
         let bucket_name = bucket_name.into();
-        let fast_map = self.fast_map.load();
-        if let Some(agent) = fast_map.get(&bucket_name) {
-            return Ok(agent.clone());
-        }
+        loop {
+            let fast_map = self.fast_map.load();
+            if let Some(agent) = fast_map.get(&bucket_name) {
+                return Ok(agent.clone());
+            }
 
-        self.get_bucket_agent_slow(bucket_name).await
+            self.load_bucket_agent_slow(&bucket_name).await?;
+
+            let slow_map = self.slow_map.lock().await;
+            let mut fast_map = HashMap::with_capacity(slow_map.len());
+            for (name, agent) in slow_map.iter() {
+                fast_map.insert(name.clone(), Arc::downgrade(agent));
+            }
+
+            self.fast_map.store(Arc::new(fast_map));
+        }
     }
 
-    async fn get_bucket_agent_slow(&self, bucket_name: impl Into<String>) -> error::Result<Agent> {
+    async fn load_bucket_agent_slow(&self, bucket_name: impl Into<String>) -> error::Result<()> {
         let bucket_name = bucket_name.into();
         let notif = {
             let mut slow_map = self.slow_map.lock().await;
-            if let Some(agent) = slow_map.get(&bucket_name) {
-                return Ok(agent.clone());
+            if slow_map.contains_key(&bucket_name) {
+                return Ok(());
             }
 
             debug!(
@@ -75,7 +90,7 @@ impl OnDemandAgentManager {
                 debug!("Bucket name {} in notif map, awaiting update", &bucket_name);
                 notif.notified().await;
                 debug!("Bucket name {} received updated", &bucket_name);
-                return Box::pin(self.get_bucket_agent_slow(bucket_name)).await;
+                return Ok(());
             };
 
             debug!("Bucket name {} not in any map, creating new", &bucket_name);
@@ -88,10 +103,10 @@ impl OnDemandAgentManager {
         let mut opts: AgentOptions = self.opts.clone().into();
         opts.bucket_name = Some(bucket_name.clone());
 
-        let agent = Agent::new(opts).await?;
+        let agent = Arc::new(Agent::new(opts).await?);
 
         let mut slow_map = self.slow_map.lock().await;
-        slow_map.insert(bucket_name.clone(), agent.clone());
+        slow_map.insert(bucket_name.clone(), agent);
 
         {
             // We remove the entry from the notif map, whilst still under the slow_map lock.
@@ -99,15 +114,8 @@ impl OnDemandAgentManager {
             notif_map.remove(&bucket_name);
         }
 
-        let mut fast_map = HashMap::with_capacity(slow_map.len());
-        for (name, agent) in slow_map.iter() {
-            fast_map.insert(name.clone(), agent.clone());
-        }
-
-        self.fast_map.store(Arc::new(fast_map));
-
         notif.notify_waiters();
 
-        Ok(agent)
+        Ok(())
     }
 }

--- a/sdk/couchbase-core/tests/agent_ops.rs
+++ b/sdk/couchbase-core/tests/agent_ops.rs
@@ -604,7 +604,7 @@ fn test_unknown_collection_id() {
         let value = generate_bytes_value(32);
 
         create_collection_and_wait_for_kv(
-            agent.clone(),
+            &agent,
             &bucket,
             &scope_name,
             &collection_name,
@@ -627,7 +627,7 @@ fn test_unknown_collection_id() {
         assert!(upsert_result.mutation_token.is_some());
 
         delete_collection_and_wait_for_kv(
-            agent.clone(),
+            &agent,
             &bucket,
             &scope_name,
             &collection_name,
@@ -665,8 +665,6 @@ fn test_unknown_collection_id() {
             },
         )
         .await;
-
-        agent.close().await;
     });
 }
 
@@ -690,7 +688,7 @@ fn test_changed_collection_id() {
         let value = generate_bytes_value(32);
 
         create_collection_and_wait_for_kv(
-            agent.clone(),
+            &agent,
             &bucket,
             &scope_name,
             &collection_name,
@@ -713,7 +711,7 @@ fn test_changed_collection_id() {
         assert!(upsert_result.mutation_token.is_some());
 
         delete_collection_and_wait_for_kv(
-            agent.clone(),
+            &agent,
             &bucket,
             &scope_name,
             &collection_name,
@@ -722,7 +720,7 @@ fn test_changed_collection_id() {
         .await;
 
         create_collection_and_wait_for_kv(
-            agent.clone(),
+            &agent,
             &bucket,
             &scope_name,
             &collection_name,
@@ -745,8 +743,6 @@ fn test_changed_collection_id() {
 
         assert_ne!(0, upsert_result.cas);
         assert!(upsert_result.mutation_token.is_some());
-
-        agent.close().await;
     });
 }
 

--- a/sdk/couchbase-core/tests/common/helpers.rs
+++ b/sdk/couchbase-core/tests/common/helpers.rs
@@ -61,7 +61,7 @@ pub fn generate_string_value(len: usize) -> String {
 }
 
 pub async fn create_collection_and_wait_for_kv(
-    agent: Agent,
+    agent: &Agent,
     bucket_name: &str,
     scope_name: &str,
     collection_name: &str,
@@ -93,7 +93,7 @@ pub async fn create_collection_and_wait_for_kv(
 }
 
 pub async fn delete_collection_and_wait_for_kv(
-    agent: Agent,
+    agent: &Agent,
     bucket_name: &str,
     scope_name: &str,
     collection_name: &str,

--- a/sdk/couchbase-core/tests/common/test_agent.rs
+++ b/sdk/couchbase-core/tests/common/test_agent.rs
@@ -24,7 +24,8 @@ use couchbase_core::results::query::QueryResultStream;
 use couchbase_core::results::search::SearchResultStream;
 use couchbase_core::searchx;
 use couchbase_core::searchx::document_analysis::DocumentAnalysis;
-use std::ops::{Add, Deref, DerefMut};
+use std::ops::{Add, Deref};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::{timeout_at, Instant};
 
@@ -32,7 +33,7 @@ use tokio::time::{timeout_at, Instant};
 pub struct TestAgent {
     pub test_setup_config: TestSetupConfig,
     pub cluster_version: NodeVersion,
-    agent: Agent,
+    agent: Arc<Agent>,
 }
 
 impl TestAgent {
@@ -44,7 +45,7 @@ impl TestAgent {
         Self {
             test_setup_config,
             cluster_version,
-            agent,
+            agent: Arc::new(agent),
         }
     }
 }
@@ -54,12 +55,6 @@ impl Deref for TestAgent {
 
     fn deref(&self) -> &Self::Target {
         &self.agent
-    }
-}
-
-impl DerefMut for TestAgent {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.agent
     }
 }
 

--- a/sdk/couchbase-core/tests/mgmt.rs
+++ b/sdk/couchbase-core/tests/mgmt.rs
@@ -165,8 +165,6 @@ fn test_create_couchbase_bucket() {
             bucket.bucket_settings.bucket_type,
             Some(BucketType::COUCHBASE)
         );
-
-        agent.close().await;
     });
 }
 
@@ -203,8 +201,6 @@ fn test_create_ephemeral_bucket() {
             bucket.bucket_settings.bucket_type,
             Some(BucketType::EPHEMERAL)
         );
-
-        agent.close().await;
     });
 }
 
@@ -265,8 +261,6 @@ fn test_update_bucket() {
             bucket.bucket_settings.max_ttl,
             Some(Duration::from_secs(3600))
         );
-
-        agent.close().await;
     });
 }
 

--- a/sdk/couchbase/src/clients/bucket_mgmt_client.rs
+++ b/sdk/couchbase/src/clients/bucket_mgmt_client.rs
@@ -138,7 +138,9 @@ impl CouchbaseBucketMgmtClient {
         let opts = couchbase_core::options::management::GetAllBucketsOptions::new()
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let buckets = agent.get_all_buckets(&opts).await?;
+        let buckets = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_all_buckets(&opts)
+            .await?;
 
         Ok(buckets.into_iter().map(|b| b.into()).collect())
     }
@@ -152,7 +154,9 @@ impl CouchbaseBucketMgmtClient {
         let opts = couchbase_core::options::management::GetBucketOptions::new(&bucket_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let bucket = agent.get_bucket(&opts).await?;
+        let bucket = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_bucket(&opts)
+            .await?;
 
         Ok(bucket.into())
     }
@@ -229,7 +233,9 @@ impl CouchbaseBucketMgmtClient {
         )
         .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.create_bucket(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .create_bucket(&opts)
+            .await?;
 
         Ok(())
     }
@@ -302,7 +308,9 @@ impl CouchbaseBucketMgmtClient {
         )
         .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.update_bucket(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .update_bucket(&opts)
+            .await?;
 
         Ok(())
     }
@@ -316,7 +324,9 @@ impl CouchbaseBucketMgmtClient {
         let opts = couchbase_core::options::management::DeleteBucketOptions::new(&bucket_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.delete_bucket(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .delete_bucket(&opts)
+            .await?;
 
         Ok(())
     }
@@ -329,7 +339,9 @@ impl CouchbaseBucketMgmtClient {
         let agent = self.agent_provider.get_agent().await;
         let opts = couchbase_core::options::management::FlushBucketOptions::new(&bucket_name)
             .retry_strategy(self.default_retry_strategy.clone());
-        agent.flush_bucket(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .flush_bucket(&opts)
+            .await?;
 
         Ok(())
     }

--- a/sdk/couchbase/src/clients/collections_mgmt_client.rs
+++ b/sdk/couchbase/src/clients/collections_mgmt_client.rs
@@ -155,7 +155,7 @@ impl CouchbaseCollectionsMgmtClient {
         opts: CreateScopeOptions,
     ) -> error::Result<()> {
         let agent = self.agent_provider.get_agent().await;
-        agent
+        CouchbaseAgentProvider::upgrade_agent(agent)?
             .create_scope(
                 &couchbase_core::options::management::CreateScopeOptions::new(
                     &self.bucket_name,
@@ -174,7 +174,7 @@ impl CouchbaseCollectionsMgmtClient {
         opts: DropScopeOptions,
     ) -> error::Result<()> {
         let agent = self.agent_provider.get_agent().await;
-        agent
+        CouchbaseAgentProvider::upgrade_agent(agent)?
             .delete_scope(
                 &couchbase_core::options::management::DeleteScopeOptions::new(
                     &self.bucket_name,
@@ -212,7 +212,9 @@ impl CouchbaseCollectionsMgmtClient {
             opts = opts.history_enabled(history_enabled);
         }
 
-        agent.create_collection(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .create_collection(&opts)
+            .await?;
 
         Ok(())
     }
@@ -242,7 +244,9 @@ impl CouchbaseCollectionsMgmtClient {
             opts = opts.history_enabled(history_enabled);
         }
 
-        agent.update_collection(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .update_collection(&opts)
+            .await?;
 
         Ok(())
     }
@@ -254,7 +258,7 @@ impl CouchbaseCollectionsMgmtClient {
         opts: DropCollectionOptions,
     ) -> error::Result<()> {
         let agent = self.agent_provider.get_agent().await;
-        agent
+        CouchbaseAgentProvider::upgrade_agent(agent)?
             .delete_collection(
                 &couchbase_core::options::management::DeleteCollectionOptions::new(
                     &self.bucket_name,
@@ -270,7 +274,7 @@ impl CouchbaseCollectionsMgmtClient {
 
     pub async fn get_all_scopes(&self, opts: GetAllScopesOptions) -> error::Result<Vec<ScopeSpec>> {
         let agent = self.agent_provider.get_agent().await;
-        let manifest = agent
+        let manifest = CouchbaseAgentProvider::upgrade_agent(agent)?
             .get_collection_manifest(
                 &couchbase_core::options::management::GetCollectionManifestOptions::new(
                     &self.bucket_name,

--- a/sdk/couchbase/src/clients/couchbase_core_kv_client.rs
+++ b/sdk/couchbase/src/clients/couchbase_core_kv_client.rs
@@ -54,7 +54,7 @@ impl CouchbaseCoreKvClient {
         options: UpsertOptions,
     ) -> error::Result<MutationResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .upsert(
                 couchbase_core::options::crud::UpsertOptions::new(
                     id.as_bytes(),
@@ -88,7 +88,7 @@ impl CouchbaseCoreKvClient {
         options: InsertOptions,
     ) -> error::Result<MutationResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .add(
                 couchbase_core::options::crud::AddOptions::new(
                     id.as_bytes(),
@@ -121,7 +121,7 @@ impl CouchbaseCoreKvClient {
         options: ReplaceOptions,
     ) -> error::Result<MutationResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .replace(
                 couchbase_core::options::crud::ReplaceOptions::new(
                     id.as_bytes(),
@@ -150,7 +150,7 @@ impl CouchbaseCoreKvClient {
 
     pub async fn remove(&self, id: &str, options: RemoveOptions) -> error::Result<MutationResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .delete(
                 couchbase_core::options::crud::DeleteOptions::new(
                     id.as_bytes(),
@@ -204,7 +204,7 @@ impl CouchbaseCoreKvClient {
             });
         }
 
-        let res = agent
+        let res = CouchbaseAgentProvider::upgrade_agent(agent)?
             .get(
                 couchbase_core::options::crud::GetOptions::new(
                     id.as_bytes(),
@@ -220,7 +220,7 @@ impl CouchbaseCoreKvClient {
 
     pub async fn exists(&self, id: &str, _options: ExistsOptions) -> error::Result<ExistsResult> {
         let agent = self.agent_provider.get_agent().await;
-        let res = agent
+        let res = CouchbaseAgentProvider::upgrade_agent(agent)?
             .get_meta(
                 couchbase_core::options::crud::GetMetaOptions::new(
                     id.as_bytes(),
@@ -241,7 +241,7 @@ impl CouchbaseCoreKvClient {
         _options: GetAndTouchOptions,
     ) -> error::Result<GetResult> {
         let agent = self.agent_provider.get_agent().await;
-        let res = agent
+        let res = CouchbaseAgentProvider::upgrade_agent(agent)?
             .get_and_touch(
                 couchbase_core::options::crud::GetAndTouchOptions::new(
                     id.as_bytes(),
@@ -263,7 +263,7 @@ impl CouchbaseCoreKvClient {
         _options: GetAndLockOptions,
     ) -> error::Result<GetResult> {
         let agent = self.agent_provider.get_agent().await;
-        let res = agent
+        let res = CouchbaseAgentProvider::upgrade_agent(agent)?
             .get_and_lock(
                 couchbase_core::options::crud::GetAndLockOptions::new(
                     id.as_bytes(),
@@ -280,7 +280,7 @@ impl CouchbaseCoreKvClient {
 
     pub async fn unlock(&self, id: &str, cas: u64, _options: UnlockOptions) -> error::Result<()> {
         let agent = self.agent_provider.get_agent().await;
-        agent
+        CouchbaseAgentProvider::upgrade_agent(agent)?
             .unlock(
                 couchbase_core::options::crud::UnlockOptions::new(
                     id.as_bytes(),
@@ -302,7 +302,7 @@ impl CouchbaseCoreKvClient {
         _options: TouchOptions,
     ) -> error::Result<TouchResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .touch(
                 couchbase_core::options::crud::TouchOptions::new(
                     id.as_bytes(),
@@ -324,7 +324,7 @@ impl CouchbaseCoreKvClient {
         options: AppendOptions,
     ) -> error::Result<MutationResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .append(
                 couchbase_core::options::crud::AppendOptions::new(
                     id.as_bytes(),
@@ -354,7 +354,7 @@ impl CouchbaseCoreKvClient {
         options: PrependOptions,
     ) -> error::Result<MutationResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .prepend(
                 couchbase_core::options::crud::PrependOptions::new(
                     id.as_bytes(),
@@ -383,7 +383,7 @@ impl CouchbaseCoreKvClient {
         options: IncrementOptions,
     ) -> error::Result<CounterResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .increment(
                 couchbase_core::options::crud::IncrementOptions::new(
                     id.as_bytes(),
@@ -415,7 +415,7 @@ impl CouchbaseCoreKvClient {
         options: DecrementOptions,
     ) -> error::Result<CounterResult> {
         let agent = self.agent_provider.get_agent().await;
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .decrement(
                 couchbase_core::options::crud::DecrementOptions::new(
                     id.as_bytes(),
@@ -450,7 +450,7 @@ impl CouchbaseCoreKvClient {
         let agent = self.agent_provider.get_agent().await;
         let (ordered_specs, op_indexes) = reorder_subdoc_ops(specs);
 
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .lookup_in(
                 couchbase_core::options::crud::LookupInOptions::new(
                     id.as_bytes(),
@@ -500,7 +500,7 @@ impl CouchbaseCoreKvClient {
         let agent = self.agent_provider.get_agent().await;
         let (ordered_specs, op_indexes) = reorder_subdoc_ops(specs);
 
-        let result = agent
+        let result = CouchbaseAgentProvider::upgrade_agent(agent)?
             .mutate_in(
                 couchbase_core::options::crud::MutateInOptions::new(
                     id.as_bytes(),

--- a/sdk/couchbase/src/clients/diagnostics_client.rs
+++ b/sdk/couchbase/src/clients/diagnostics_client.rs
@@ -78,7 +78,9 @@ impl CouchbaseDiagnosticsClient {
             couchbase_core::options::diagnostics::DiagnosticsOptions::new()
         };
 
-        let report = agent.diagnostics(&core_opts).await?;
+        let report = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .diagnostics(&core_opts)
+            .await?;
 
         Ok(DiagnosticsResult::from(report))
     }
@@ -92,7 +94,9 @@ impl CouchbaseDiagnosticsClient {
             couchbase_core::options::ping::PingOptions::new()
         };
 
-        let report = agent.ping(&core_opts).await?;
+        let report = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .ping(&core_opts)
+            .await?;
 
         Ok(PingReport::from(report))
     }
@@ -106,7 +110,9 @@ impl CouchbaseDiagnosticsClient {
             couchbase_core::options::waituntilready::WaitUntilReadyOptions::new()
         };
 
-        Ok(agent.wait_until_ready(&core_opts).await?)
+        Ok(CouchbaseAgentProvider::upgrade_agent(agent)?
+            .wait_until_ready(&core_opts)
+            .await?)
     }
 }
 

--- a/sdk/couchbase/src/clients/query_client.rs
+++ b/sdk/couchbase/src/clients/query_client.rs
@@ -84,9 +84,17 @@ impl CouchbaseQueryClient {
 
         let agent = self.agent_provider.get_agent().await;
         if ad_hoc {
-            Ok(QueryResult::from(agent.query(query_opts).await?))
+            Ok(QueryResult::from(
+                CouchbaseAgentProvider::upgrade_agent(agent)?
+                    .query(query_opts)
+                    .await?,
+            ))
         } else {
-            Ok(QueryResult::from(agent.prepared_query(query_opts).await?))
+            Ok(QueryResult::from(
+                CouchbaseAgentProvider::upgrade_agent(agent)?
+                    .prepared_query(query_opts)
+                    .await?,
+            ))
         }
     }
 }

--- a/sdk/couchbase/src/clients/query_index_mgmt_client.rs
+++ b/sdk/couchbase/src/clients/query_index_mgmt_client.rs
@@ -166,7 +166,9 @@ impl CouchbaseQueryIndexMgmtClient {
 
         let agent = self.agent_provider.get_agent().await;
 
-        let indexes = agent.get_all_indexes(&get_indexes_opts).await?;
+        let indexes = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_all_indexes(&get_indexes_opts)
+            .await?;
 
         Ok(indexes.into_iter().map(QueryIndex::from).collect())
     }
@@ -204,7 +206,9 @@ impl CouchbaseQueryIndexMgmtClient {
 
         let agent = self.agent_provider.get_agent().await;
 
-        agent.create_index(&create_index_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .create_index(&create_index_opts)
+            .await?;
         Ok(())
     }
 
@@ -236,7 +240,9 @@ impl CouchbaseQueryIndexMgmtClient {
 
         let agent = self.agent_provider.get_agent().await;
 
-        agent.create_primary_index(&create_index_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .create_primary_index(&create_index_opts)
+            .await?;
 
         Ok(())
     }
@@ -262,7 +268,9 @@ impl CouchbaseQueryIndexMgmtClient {
 
         let agent = self.agent_provider.get_agent().await;
 
-        agent.drop_index(&drop_index_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .drop_index(&drop_index_opts)
+            .await?;
 
         Ok(())
     }
@@ -289,7 +297,9 @@ impl CouchbaseQueryIndexMgmtClient {
 
         let agent = self.agent_provider.get_agent().await;
 
-        agent.drop_primary_index(&drop_index_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .drop_primary_index(&drop_index_opts)
+            .await?;
 
         Ok(())
     }
@@ -317,7 +327,9 @@ impl CouchbaseQueryIndexMgmtClient {
 
         let agent = self.agent_provider.get_agent().await;
 
-        agent.watch_indexes(&watch_indexes_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .watch_indexes(&watch_indexes_opts)
+            .await?;
 
         Ok(())
     }
@@ -339,7 +351,9 @@ impl CouchbaseQueryIndexMgmtClient {
 
         let agent = self.agent_provider.get_agent().await;
 
-        agent.build_deferred_indexes(&build_indexes_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .build_deferred_indexes(&build_indexes_opts)
+            .await?;
 
         Ok(())
     }

--- a/sdk/couchbase/src/clients/search_client.rs
+++ b/sdk/couchbase/src/clients/search_client.rs
@@ -202,7 +202,11 @@ impl CouchbaseSearchClient {
             .retry_strategy(self.default_retry_strategy.clone());
 
         let agent = self.agent_provider.get_agent().await;
-        Ok(SearchResult::from(agent.search(core_opts).await?))
+        Ok(SearchResult::from(
+            CouchbaseAgentProvider::upgrade_agent(agent)?
+                .search(core_opts)
+                .await?,
+        ))
     }
 }
 

--- a/sdk/couchbase/src/clients/search_index_mgmt_client.rs
+++ b/sdk/couchbase/src/clients/search_index_mgmt_client.rs
@@ -244,7 +244,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let index = agent.get_search_index(&get_opts).await?;
+        let index = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_search_index(&get_opts)
+            .await?;
         Ok(index.into())
     }
 
@@ -261,7 +263,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let indexes = agent.get_all_search_indexes(&get_all_opts).await?;
+        let indexes = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_all_search_indexes(&get_all_opts)
+            .await?;
 
         Ok(indexes.into_iter().map(SearchIndex::from).collect())
     }
@@ -280,7 +284,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.upsert_search_index(&upsert_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .upsert_search_index(&upsert_opts)
+            .await?;
         Ok(())
     }
 
@@ -297,7 +303,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.delete_search_index(&delete_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .delete_search_index(&delete_opts)
+            .await?;
         Ok(())
     }
 
@@ -318,7 +326,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let analysis = agent.analyze_search_document(&analyze_opts).await?;
+        let analysis = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .analyze_search_document(&analyze_opts)
+            .await?;
 
         let analysed = serde_json::from_slice(&analysis.analyzed)
             .map_err(error::Error::decoding_failure_from_serde)?;
@@ -339,7 +349,7 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let count = agent
+        let count = CouchbaseAgentProvider::upgrade_agent(agent)?
             .get_search_indexed_documents_count(&count_opts)
             .await?;
         Ok(count)
@@ -358,7 +368,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.pause_search_index_ingest(&pause_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .pause_search_index_ingest(&pause_opts)
+            .await?;
         Ok(())
     }
 
@@ -375,7 +387,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.resume_search_index_ingest(&resume_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .resume_search_index_ingest(&resume_opts)
+            .await?;
         Ok(())
     }
 
@@ -392,7 +406,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.allow_search_index_querying(&allow_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .allow_search_index_querying(&allow_opts)
+            .await?;
         Ok(())
     }
 
@@ -409,7 +425,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.disallow_search_index_querying(&disallow_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .disallow_search_index_querying(&disallow_opts)
+            .await?;
         Ok(())
     }
 
@@ -426,7 +444,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.freeze_search_index_plan(&freeze_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .freeze_search_index_plan(&freeze_opts)
+            .await?;
         Ok(())
     }
 
@@ -443,7 +463,9 @@ impl CouchbaseSearchIndexMgmtClient {
             .scope_name(&self.keyspace.scope_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.unfreeze_search_index_plan(&unfreeze_opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .unfreeze_search_index_plan(&unfreeze_opts)
+            .await?;
         Ok(())
     }
 }

--- a/sdk/couchbase/src/clients/user_mgmt_client.rs
+++ b/sdk/couchbase/src/clients/user_mgmt_client.rs
@@ -181,7 +181,9 @@ impl CouchbaseUserMgmtClient {
         )
         .retry_strategy(self.default_retry_strategy.clone());
 
-        let users = agent.get_all_users(&opts).await?;
+        let users = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_all_users(&opts)
+            .await?;
 
         Ok(users.into_iter().map(|u| u.into()).collect())
     }
@@ -198,7 +200,9 @@ impl CouchbaseUserMgmtClient {
         )
         .retry_strategy(self.default_retry_strategy.clone());
 
-        let user = agent.get_user(&opts).await?;
+        let user = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_user(&opts)
+            .await?;
 
         Ok(user.into())
     }
@@ -213,7 +217,9 @@ impl CouchbaseUserMgmtClient {
         )
         .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.upsert_user(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .upsert_user(&opts)
+            .await?;
 
         Ok(())
     }
@@ -226,7 +232,9 @@ impl CouchbaseUserMgmtClient {
         )
         .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.delete_user(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .delete_user(&opts)
+            .await?;
 
         Ok(())
     }
@@ -236,7 +244,9 @@ impl CouchbaseUserMgmtClient {
         let opts = couchbase_core::options::management::GetRolesOptions::new()
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let roles = agent.get_roles(&opts).await?;
+        let roles = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_roles(&opts)
+            .await?;
 
         Ok(roles.into_iter().map(|r| r.into()).collect())
     }
@@ -250,7 +260,9 @@ impl CouchbaseUserMgmtClient {
         let opts = couchbase_core::options::management::GetGroupOptions::new(&group_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let group = agent.get_group(&opts).await?;
+        let group = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_group(&opts)
+            .await?;
 
         Ok(group.into())
     }
@@ -260,7 +272,9 @@ impl CouchbaseUserMgmtClient {
         let opts = couchbase_core::options::management::GetAllGroupsOptions::new()
             .retry_strategy(self.default_retry_strategy.clone());
 
-        let groups = agent.get_all_groups(&opts).await?;
+        let groups = CouchbaseAgentProvider::upgrade_agent(agent)?
+            .get_all_groups(&opts)
+            .await?;
 
         Ok(groups.into_iter().map(|g| g.into()).collect())
     }
@@ -272,7 +286,9 @@ impl CouchbaseUserMgmtClient {
         let opts = couchbase_core::options::management::UpsertGroupOptions::new(&cgroup)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.upsert_group(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .upsert_group(&opts)
+            .await?;
 
         Ok(())
     }
@@ -286,7 +302,9 @@ impl CouchbaseUserMgmtClient {
         let opts = couchbase_core::options::management::DeleteGroupOptions::new(&group_name)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.delete_group(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .delete_group(&opts)
+            .await?;
 
         Ok(())
     }
@@ -300,7 +318,9 @@ impl CouchbaseUserMgmtClient {
         let opts = couchbase_core::options::management::ChangePasswordOptions::new(&new_password)
             .retry_strategy(self.default_retry_strategy.clone());
 
-        agent.change_password(&opts).await?;
+        CouchbaseAgentProvider::upgrade_agent(agent)?
+            .change_password(&opts)
+            .await?;
 
         Ok(())
     }

--- a/sdk/couchbase/src/error.rs
+++ b/sdk/couchbase/src/error.rs
@@ -143,6 +143,8 @@ impl StdError for Error {}
 pub enum ErrorKind {
     OtherFailure(String),
     ServerTimeout,
+    Disconnected,
+
     // Shared Error Definitions RFC#58@16
     InvalidArgument(InvalidArgumentErrorKind),
     ServiceNotAvailable(ServiceType),
@@ -227,6 +229,9 @@ impl Display for ErrorKind {
                 } else {
                     write!(f, "invalid argument: {msg}")
                 };
+            }
+            ErrorKind::Disconnected => {
+                "the client is disconnected (have the parent bucket or cluster been dropped?)"
             }
             ErrorKind::ServiceNotAvailable(service) => {
                 return write!(f, "service not available: {service}");

--- a/sdk/couchbase/tests/connections.rs
+++ b/sdk/couchbase/tests/connections.rs
@@ -1,0 +1,208 @@
+use crate::common::test_config::{create_test_cluster, run_test};
+use crate::common::{new_key, try_until};
+use couchbase::error::ErrorKind;
+use std::ops::Add;
+use std::time::Duration;
+use tokio::time::Instant;
+
+mod common;
+
+// Tests in this file use try_until as it takes some time for the drop chain to be realized.
+
+#[test]
+fn test_collection_use_after_cluster_drop() {
+    run_test(async |_cluster| {
+        let collection = {
+            let cluster = create_test_cluster().await;
+
+            cluster
+                .bucket(cluster.default_bucket())
+                .scope(cluster.default_scope())
+                .collection(cluster.default_collection())
+        };
+
+        let key = new_key();
+
+        try_until(
+            Instant::now().add(Duration::from_millis(1000)),
+            Duration::from_millis(10),
+            "operation didn't fail with disconnected",
+            async || {
+                let err = match collection.upsert(&key, "test", None).await {
+                    Ok(_) => return Ok(None),
+                    Err(e) => e,
+                };
+
+                if &ErrorKind::Disconnected == err.kind() {
+                    return Ok(Some(()));
+                }
+
+                Ok(None)
+            },
+        )
+        .await;
+    })
+}
+
+#[test]
+fn test_collection_level_mgr_use_after_cluster_drop() {
+    run_test(async |_cluster| {
+        let mgr = {
+            let cluster = create_test_cluster().await;
+
+            let collection = cluster
+                .bucket(cluster.default_bucket())
+                .scope(cluster.default_scope())
+                .collection(cluster.default_collection());
+
+            collection.query_indexes()
+        };
+
+        try_until(
+            Instant::now().add(Duration::from_millis(1000)),
+            Duration::from_millis(10),
+            "operation didn't fail with disconnected",
+            async || {
+                let err = match mgr.get_all_indexes(None).await {
+                    Ok(_) => return Ok(None),
+                    Err(e) => e,
+                };
+
+                if &ErrorKind::Disconnected == err.kind() {
+                    return Ok(Some(()));
+                }
+
+                Ok(None)
+            },
+        )
+        .await;
+    })
+}
+
+#[test]
+fn test_scope_use_after_cluster_drop() {
+    run_test(async |_cluster| {
+        let scope = {
+            let cluster = create_test_cluster().await;
+
+            cluster
+                .bucket(cluster.default_bucket())
+                .scope(cluster.default_scope())
+        };
+
+        try_until(
+            Instant::now().add(Duration::from_millis(1000)),
+            Duration::from_millis(10),
+            "operation didn't fail with disconnected",
+            async || {
+                let err = match scope.query("SELECT 1=1", None).await {
+                    Ok(_) => return Ok(None),
+                    Err(e) => e,
+                };
+
+                if &ErrorKind::Disconnected == err.kind() {
+                    return Ok(Some(()));
+                }
+
+                Ok(None)
+            },
+        )
+        .await;
+    })
+}
+
+#[test]
+fn test_scope_level_mgr_use_after_cluster_drop() {
+    run_test(async |_cluster| {
+        let mgr = {
+            let cluster = create_test_cluster().await;
+
+            let scope = cluster
+                .bucket(cluster.default_bucket())
+                .scope(cluster.default_scope());
+
+            scope.search_indexes()
+        };
+
+        try_until(
+            Instant::now().add(Duration::from_millis(1000)),
+            Duration::from_millis(10),
+            "operation didn't fail with disconnected",
+            async || {
+                let err = match mgr.get_all_indexes(None).await {
+                    Ok(_) => return Ok(None),
+                    Err(e) => e,
+                };
+
+                if &ErrorKind::Disconnected == err.kind() {
+                    return Ok(Some(()));
+                }
+
+                Ok(None)
+            },
+        )
+        .await;
+    })
+}
+
+#[test]
+fn test_bucket_level_mgr_use_after_cluster_drop() {
+    run_test(async |_cluster| {
+        let mgr = {
+            let cluster = create_test_cluster().await;
+
+            let bucket = cluster.bucket(cluster.default_bucket());
+
+            bucket.collections()
+        };
+
+        try_until(
+            Instant::now().add(Duration::from_millis(1000)),
+            Duration::from_millis(10),
+            "operation didn't fail with disconnected",
+            async || {
+                let err = match mgr.get_all_scopes(None).await {
+                    Ok(_) => return Ok(None),
+                    Err(e) => e,
+                };
+
+                if &ErrorKind::Disconnected == err.kind() {
+                    return Ok(Some(()));
+                }
+
+                Ok(None)
+            },
+        )
+        .await;
+    })
+}
+
+#[test]
+fn test_cluster_level_mgr_use_after_cluster_drop() {
+    run_test(async |_cluster| {
+        let mgr = {
+            let cluster = create_test_cluster().await;
+
+            cluster.users()
+        };
+
+        try_until(
+            Instant::now().add(Duration::from_millis(1000)),
+            Duration::from_millis(10),
+            "operation didn't fail with disconnected",
+            async || {
+                let err = match mgr.get_all_groups(None).await {
+                    Ok(_) => return Ok(None),
+                    Err(e) => e,
+                };
+
+                if &ErrorKind::Disconnected == err.kind() {
+                    return Ok(Some(()));
+                }
+
+                Ok(None)
+            },
+        )
+        .await;
+    })
+}


### PR DESCRIPTION
Motivation
----------
When the top level resource, be it agent/agent manager/cluster, is dropped then all lower level resources such as connections should be dropped and tasks aborted.

Changes
-------