### PR TITLE
RSCBC-168: Query result metrics is also present even when metrics are not requested

### DIFF
--- a/sdk/couchbase-core/src/queryx/query_respreader.rs
+++ b/sdk/couchbase-core/src/queryx/query_respreader.rs
@@ -263,33 +263,31 @@ impl QueryRespReader {
         })
     }
 
-    fn parse_metrics(&self, metrics: Option<QueryMetrics>) -> Metrics {
-        if let Some(metrics) = metrics {
-            let elapsed_time = if let Some(elapsed) = metrics.elapsed_time {
+    fn parse_metrics(&self, metrics: Option<QueryMetrics>) -> Option<Metrics> {
+        metrics.map(|m| {
+            let elapsed_time = if let Some(elapsed) = m.elapsed_time {
                 parse_duration_from_golang_string(&elapsed).unwrap_or_default()
             } else {
                 Duration::default()
             };
 
-            let execution_time = if let Some(execution) = metrics.execution_time {
+            let execution_time = if let Some(execution) = m.execution_time {
                 parse_duration_from_golang_string(&execution).unwrap_or_default()
             } else {
                 Duration::default()
             };
 
-            return Metrics {
+            Metrics {
                 elapsed_time,
                 execution_time,
-                result_count: metrics.result_count.unwrap_or_default(),
-                result_size: metrics.result_size.unwrap_or_default(),
-                mutation_count: metrics.mutation_count.unwrap_or_default(),
-                sort_count: metrics.sort_count.unwrap_or_default(),
-                error_count: metrics.error_count.unwrap_or_default(),
-                warning_count: metrics.warning_count.unwrap_or_default(),
-            };
-        }
-
-        Metrics::default()
+                result_count: m.result_count.unwrap_or_default(),
+                result_size: m.result_size.unwrap_or_default(),
+                mutation_count: m.mutation_count.unwrap_or_default(),
+                sort_count: m.sort_count.unwrap_or_default(),
+                error_count: m.error_count.unwrap_or_default(),
+                warning_count: m.warning_count.unwrap_or_default(),
+            }
+        })
     }
 
     fn parse_warnings(&self, warnings: Vec<QueryWarning>) -> Vec<Warning> {

--- a/sdk/couchbase-core/src/queryx/query_result.rs
+++ b/sdk/couchbase-core/src/queryx/query_result.rs
@@ -48,7 +48,7 @@ pub struct MetaData {
     pub request_id: String,
     pub client_context_id: String,
     pub status: Status,
-    pub metrics: Metrics,
+    pub metrics: Option<Metrics>,
     pub signature: Option<Box<RawValue>>,
     pub warnings: Vec<Warning>,
     pub profile: Option<Box<RawValue>>,
@@ -58,7 +58,7 @@ impl Display for MetaData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "prepared: {:?}, request_id: {}, client_context_id: {}, status: {}, metrics: {}, signature: {:?}, warnings: {:?}, profile: {:?}",
+            "prepared: {:?}, request_id: {}, client_context_id: {}, status: {}, metrics: {:?}, signature: {:?}, warnings: {:?}, profile: {:?}",
             self.prepared,
             self.request_id,
             self.client_context_id,

--- a/sdk/couchbase-core/tests/query.rs
+++ b/sdk/couchbase-core/tests/query.rs
@@ -43,14 +43,19 @@ fn test_query_basic() {
         assert!(meta.profile.is_none());
         assert!(meta.warnings.is_empty());
 
-        assert!(!meta.metrics.elapsed_time.is_zero());
-        assert!(!meta.metrics.execution_time.is_zero());
-        assert_eq!(1, meta.metrics.result_count);
-        assert_ne!(0, meta.metrics.result_size);
-        assert_eq!(0, meta.metrics.mutation_count);
-        assert_eq!(0, meta.metrics.sort_count);
-        assert_eq!(0, meta.metrics.error_count);
-        assert_eq!(0, meta.metrics.warning_count);
+        let metrics = meta
+            .metrics
+            .as_ref()
+            .expect("expected metrics to be present");
+
+        assert!(!metrics.elapsed_time.is_zero());
+        assert!(!metrics.execution_time.is_zero());
+        assert_eq!(1, metrics.result_count);
+        assert_ne!(0, metrics.result_size);
+        assert_eq!(0, metrics.mutation_count);
+        assert_eq!(0, metrics.sort_count);
+        assert_eq!(0, metrics.error_count);
+        assert_eq!(0, metrics.warning_count);
 
         assert_eq!(
             "{\"$1\":\"boolean\"}",
@@ -87,14 +92,19 @@ fn test_prepared_query_basic() {
         assert!(meta.profile.is_none());
         assert!(meta.warnings.is_empty());
 
-        assert!(!meta.metrics.elapsed_time.is_zero());
-        assert!(!meta.metrics.execution_time.is_zero());
-        assert_eq!(1, meta.metrics.result_count);
-        assert_ne!(0, meta.metrics.result_size);
-        assert_eq!(0, meta.metrics.mutation_count);
-        assert_eq!(0, meta.metrics.sort_count);
-        assert_eq!(0, meta.metrics.error_count);
-        assert_eq!(0, meta.metrics.warning_count);
+        let metrics = meta
+            .metrics
+            .as_ref()
+            .expect("expected metrics to be present");
+
+        assert!(!metrics.elapsed_time.is_zero());
+        assert!(!metrics.execution_time.is_zero());
+        assert_eq!(1, metrics.result_count);
+        assert_ne!(0, metrics.result_size);
+        assert_eq!(0, metrics.mutation_count);
+        assert_eq!(0, metrics.sort_count);
+        assert_eq!(0, metrics.error_count);
+        assert_eq!(0, metrics.warning_count);
 
         dbg!(&meta.signature);
 

--- a/sdk/couchbase/src/options/query_options.rs
+++ b/sdk/couchbase/src/options/query_options.rs
@@ -245,7 +245,7 @@ impl TryFrom<QueryOptions> for query::QueryOptions {
             .args(opts.positional_parameters)
             .client_context_id(opts.client_context_id)
             .max_parallelism(opts.max_parallelism)
-            .metrics(opts.metrics)
+            .metrics(opts.metrics.unwrap_or_default())
             .pipeline_batch(opts.pipeline_batch)
             .pipeline_cap(opts.pipeline_cap)
             .preserve_expiry(opts.preserve_expiry)

--- a/sdk/couchbase/src/results/query_results.rs
+++ b/sdk/couchbase/src/results/query_results.rs
@@ -92,7 +92,7 @@ pub struct QueryMetaData<'a> {
     pub request_id: &'a str,
     pub client_context_id: &'a str,
     pub status: QueryStatus,
-    pub metrics: QueryMetrics,
+    pub metrics: Option<QueryMetrics>,
     pub signature: Option<&'a RawValue>,
     pub warnings: Vec<QueryWarning>,
     pub profile: Option<&'a RawValue>,
@@ -105,7 +105,7 @@ impl<'a> From<&'a queryx::query_result::MetaData> for QueryMetaData<'a> {
             request_id: meta.request_id.as_ref(),
             client_context_id: meta.client_context_id.as_ref(),
             status: meta.status.into(),
-            metrics: QueryMetrics::from(&meta.metrics),
+            metrics: meta.metrics.as_ref().map(QueryMetrics::from),
             signature: meta.signature.as_deref(),
             warnings: meta
                 .warnings

--- a/sdk/couchbase/tests/query.rs
+++ b/sdk/couchbase/tests/query.rs
@@ -262,14 +262,18 @@ fn assert_metadata(meta: QueryMetaData) {
     assert!(meta.profile.is_none());
     assert!(meta.warnings.is_empty());
 
-    assert!(!meta.metrics.elapsed_time.is_zero());
-    assert!(!meta.metrics.execution_time.is_zero());
-    assert_eq!(1, meta.metrics.result_count);
-    assert_ne!(0, meta.metrics.result_size);
-    assert_eq!(0, meta.metrics.mutation_count);
-    assert_eq!(0, meta.metrics.sort_count);
-    assert_eq!(0, meta.metrics.error_count);
-    assert_eq!(0, meta.metrics.warning_count);
+    let metrics = meta
+        .metrics
+        .as_ref()
+        .expect("expected metrics to be present");
+    assert!(!metrics.elapsed_time.is_zero());
+    assert!(!metrics.execution_time.is_zero());
+    assert_eq!(1, metrics.result_count);
+    assert_ne!(0, metrics.result_size);
+    assert_eq!(0, metrics.mutation_count);
+    assert_eq!(0, metrics.sort_count);
+    assert_eq!(0, metrics.error_count);
+    assert_eq!(0, metrics.warning_count);
 
     assert_eq!(
         "{\"$1\":\"boolean\"}",


### PR DESCRIPTION
Changes
---------
- Made QueryMetrics optional
- Default set `metrics` to false in the public API