### PR TITLE
RSCBC-223: Retry on reqwest Request errors

### DIFF
--- a/sdk/couchbase-core/src/analyticsx/analytics.rs
+++ b/sdk/couchbase-core/src/analyticsx/analytics.rs
@@ -138,7 +138,8 @@ impl<C: Client> Query<C> {
             Ok(r) => r,
             Err(e) => {
                 return Err(Error::new_http_error(
-                    format!("{}: {}", &self.endpoint, e),
+                    e,
+                    self.endpoint.to_string(),
                     statement,
                     client_context_id,
                 ));
@@ -165,7 +166,8 @@ impl<C: Client> Query<C> {
             Ok(r) => r,
             Err(e) => {
                 return Err(Error::new_http_error(
-                    format!("{}: {}", &self.endpoint, e),
+                    e,
+                    self.endpoint.to_string(),
                     None,
                     None,
                 ));
@@ -187,7 +189,7 @@ impl<C: Client> Query<C> {
         let pending = serde_json::from_slice(
             &res.bytes()
                 .await
-                .map_err(|e| Error::new_http_error(self.endpoint.clone(), None, None))?,
+                .map_err(|e| Error::new_http_error(e, self.endpoint.clone(), None, None))?,
         )
         .map_err(|e| {
             Error::new_message_error(
@@ -215,7 +217,8 @@ impl<C: Client> Query<C> {
             Ok(r) => r,
             Err(e) => {
                 return Err(Error::new_http_error(
-                    format!("{}: {}", &self.endpoint, e),
+                    e,
+                    self.endpoint.to_string(),
                     None,
                     None,
                 ));

--- a/sdk/couchbase-core/src/analyticsx/query_respreader.rs
+++ b/sdk/couchbase-core/src/analyticsx/query_respreader.rs
@@ -72,7 +72,8 @@ impl Stream for QueryRespReader {
                 Poll::Ready(None)
             }
             Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(Error::new_http_error(
-                format!("{}: {}", &this.endpoint, e),
+                e,
+                this.endpoint.to_string(),
                 Some(this.statement.clone()),
                 this.client_context_id.clone(),
             )))),
@@ -99,7 +100,8 @@ impl QueryRespReader {
                 Err(e) => {
                     debug!("Failed to read response body on error {}", &e);
                     return Err(Error::new_http_error(
-                        format!("{endpoint}: {e}"),
+                        e,
+                        endpoint,
                         statement,
                         client_context_id,
                     ));
@@ -146,7 +148,8 @@ impl QueryRespReader {
         // the stream to advance the streamer to the rows.
         streamer.read_prelude().await.map_err(|e| {
             Error::new_http_error(
-                format!("{endpoint}: {e}"),
+                e,
+                endpoint.clone(),
                 statement.to_string(),
                 client_context_id.to_string(),
             )
@@ -159,7 +162,8 @@ impl QueryRespReader {
                 Ok(epilog) => Some(epilog),
                 Err(e) => {
                     return Err(Error::new_http_error(
-                        format!("{endpoint}: {e}"),
+                        e,
+                        endpoint.clone(),
                         statement,
                         client_context_id,
                     ));

--- a/sdk/couchbase-core/src/httpx/client.rs
+++ b/sdk/couchbase-core/src/httpx/client.rs
@@ -249,6 +249,8 @@ impl Client for ReqwestClient {
 
                 if err.is_connect() {
                     Err(Error::new_connection_error(err.to_string()))
+                } else if err.is_request() {
+                    Err(Error::new_request_error(err.to_string()))
                 } else {
                     Err(Error::new_message_error(err.to_string()))
                 }

--- a/sdk/couchbase-core/src/httpx/error.rs
+++ b/sdk/couchbase-core/src/httpx/error.rs
@@ -59,6 +59,14 @@ impl Error {
         }
     }
 
+    pub(crate) fn new_request_error(msg: impl Into<String>) -> Self {
+        Self {
+            inner: Box::new(ErrorImpl {
+                kind: ErrorKind::SendRequest(msg.into()),
+            }),
+        }
+    }
+
     pub fn is_connection_error(&self) -> bool {
         matches!(self.inner.kind, ErrorKind::Connection { .. })
     }
@@ -86,6 +94,7 @@ pub enum ErrorKind {
     },
     Decoding(String),
     Message(String),
+    SendRequest(String),
 }
 
 impl Display for ErrorKind {
@@ -94,6 +103,7 @@ impl Display for ErrorKind {
             Self::Connection { msg } => write!(f, "connection error {msg}"),
             Self::Decoding(msg) => write!(f, "decoding error: {msg}"),
             Self::Message(msg) => write!(f, "{msg}"),
+            Self::SendRequest(msg) => write!(f, "send request failed error: {msg}"),
         }
     }
 }

--- a/sdk/couchbase-core/src/mgmtx/error.rs
+++ b/sdk/couchbase-core/src/mgmtx/error.rs
@@ -16,6 +16,7 @@
  *
  */
 
+use crate::httpx;
 use http::{Method, StatusCode};
 use std::error::Error as StdError;
 use std::fmt::{Display, Formatter};
@@ -85,6 +86,7 @@ pub enum ErrorKind {
         arg: Option<String>,
     },
     Message(String),
+    Http(httpx::error::Error),
 }
 
 impl Display for ErrorKind {
@@ -100,6 +102,7 @@ impl Display for ErrorKind {
                 }
             }
             ErrorKind::Message(msg) => write!(f, "{msg}"),
+            ErrorKind::Http(e) => write!(f, "http error: {e}"),
         }
     }
 }
@@ -302,6 +305,16 @@ impl From<ResourceError> for Error {
         Self {
             inner: Box::new(ErrorImpl {
                 kind: ErrorKind::Resource(value),
+            }),
+        }
+    }
+}
+
+impl From<httpx::error::Error> for Error {
+    fn from(value: httpx::error::Error) -> Self {
+        Self {
+            inner: Box::new(ErrorImpl {
+                kind: ErrorKind::Http(value),
             }),
         }
     }

--- a/sdk/couchbase-core/src/mgmtx/mgmt.rs
+++ b/sdk/couchbase-core/src/mgmtx/mgmt.rs
@@ -108,7 +108,7 @@ impl<C: Client> Management<C> {
         self.http_client
             .execute(req)
             .await
-            .map_err(|e| error::Error::new_message_error(format!("could not execute request: {e}")))
+            .map_err(error::Error::from)
     }
 
     pub(crate) async fn decode_common_error(

--- a/sdk/couchbase-core/src/queryx/query.rs
+++ b/sdk/couchbase-core/src/queryx/query.rs
@@ -150,7 +150,8 @@ impl<C: Client> Query<C> {
             Ok(r) => r,
             Err(e) => {
                 return Err(Error::new_http_error(
-                    format!("{}: {}", &self.endpoint, e),
+                    e,
+                    self.endpoint.to_string(),
                     statement,
                     client_context_id,
                 ));
@@ -547,7 +548,8 @@ impl<C: Client> Query<C> {
             Ok(r) => r,
             Err(e) => {
                 return Err(Error::new_http_error(
-                    format!("{}: {}", &self.endpoint, e),
+                    e,
+                    self.endpoint.to_string(),
                     None,
                     None,
                 ));

--- a/sdk/couchbase-core/src/queryx/query_respreader.rs
+++ b/sdk/couchbase-core/src/queryx/query_respreader.rs
@@ -80,7 +80,8 @@ impl Stream for QueryRespReader {
                 Poll::Ready(None)
             }
             Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(Error::new_http_error(
-                format!("{}: {}", &this.endpoint, e),
+                e,
+                this.endpoint.clone(),
                 Some(this.statement.clone()),
                 this.client_context_id.clone(),
             )))),
@@ -107,7 +108,8 @@ impl QueryRespReader {
                 Err(e) => {
                     debug!("Failed to read response body on error {}", &e);
                     return Err(Error::new_http_error(
-                        format!("{endpoint}: {e}"),
+                        e,
+                        endpoint,
                         statement,
                         client_context_id,
                     ));
@@ -162,7 +164,8 @@ impl QueryRespReader {
                 Ok(epilog) => Some(epilog),
                 Err(e) => {
                     return Err(Error::new_http_error(
-                        format!("{endpoint}: {e}"),
+                        e,
+                        endpoint,
                         statement,
                         client_context_id,
                     ));
@@ -219,7 +222,8 @@ impl QueryRespReader {
     ) -> error::Result<EarlyMetaData> {
         let prelude = streamer.read_prelude().await.map_err(|e| {
             Error::new_http_error(
-                format!("{endpoint}: {e}"),
+                e,
+                endpoint,
                 statement.to_string(),
                 client_context_id.to_string(),
             )

--- a/sdk/couchbase-core/src/searchx/search.rs
+++ b/sdk/couchbase-core/src/searchx/search.rs
@@ -136,7 +136,7 @@ impl<C: Client> Search<C> {
                 Some(Bytes::from(body)),
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         SearchRespReader::new(res, &opts.index_name, &self.endpoint).await
     }
@@ -162,7 +162,7 @@ impl<C: Client> Search<C> {
                 Some(Bytes::from(body)),
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         if res.status() != 200 {
             return Err(
@@ -190,7 +190,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(
@@ -218,7 +218,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(
@@ -256,7 +256,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(res, "".to_string(), self.endpoint.clone()).await);
@@ -295,7 +295,7 @@ impl<C: Client> Search<C> {
                 Some(body),
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(
@@ -346,7 +346,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(
@@ -447,7 +447,7 @@ impl<C: Client> Search<C> {
         {
             Ok(r) => r,
             Err(e) => {
-                return Err(Error::new_http_error(format!("{}: {}", &self.endpoint, e)));
+                return Err(Error::new_http_error(e, self.endpoint.to_string()));
             }
         };
 
@@ -503,7 +503,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         if res.status() != 200 {
             return Err(
@@ -528,7 +528,7 @@ impl<C: Client> Search<C> {
                 None,
             )
             .await
-            .map_err(|e| error::Error::new_http_error(format!("{}: {}", &self.endpoint, e)))?;
+            .map_err(|e| error::Error::new_http_error(e, self.endpoint.to_string()))?;
 
         if res.status() != 200 {
             return Err(decode_response_error(res, "".to_string(), self.endpoint.clone()).await);
@@ -569,14 +569,14 @@ pub(crate) async fn decode_response_error(
     let body = match response.bytes().await {
         Ok(b) => b,
         Err(e) => {
-            return error::Error::new_http_error(format!("{endpoint}: {e}"));
+            return Error::new_http_error(e, endpoint);
         }
     };
 
     let body_str = match String::from_utf8(body.to_vec()) {
         Ok(s) => s.to_lowercase(),
         Err(e) => {
-            return error::Error::new_message_error(
+            return Error::new_message_error(
                 format!("could not parse error response: {e}"),
                 endpoint,
             );

--- a/sdk/couchbase-core/src/searchx/search_respreader.rs
+++ b/sdk/couchbase-core/src/searchx/search_respreader.rs
@@ -78,9 +78,9 @@ impl Stream for SearchRespReader {
                 }
                 Poll::Ready(None)
             }
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(error::Error::new_http_error(
-                format!("{}: {}", &this.endpoint, e),
-            )))),
+            Poll::Ready(Some(Err(e))) => {
+                Poll::Ready(Some(Err(error::Error::new_http_error(e, &this.endpoint))))
+            }
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }
@@ -102,7 +102,7 @@ impl SearchRespReader {
                 Ok(b) => b,
                 Err(e) => {
                     debug!("Failed to read response body on error {e}");
-                    return Err(error::Error::new_http_error(format!("{endpoint}: {e}")));
+                    return Err(error::Error::new_http_error(e, endpoint));
                 }
             };
 
@@ -132,7 +132,7 @@ impl SearchRespReader {
         match streamer.read_prelude().await {
             Ok(_) => {}
             Err(e) => {
-                return Err(error::Error::new_http_error(format!("{endpoint}: {e}")));
+                return Err(error::Error::new_http_error(e, endpoint));
             }
         };
 
@@ -142,7 +142,7 @@ impl SearchRespReader {
             epilog = match streamer.epilog() {
                 Ok(epilog) => Some(epilog),
                 Err(e) => {
-                    return Err(error::Error::new_http_error(format!("{endpoint}: {e}")));
+                    return Err(error::Error::new_http_error(e, endpoint));
                 }
             };
         }


### PR DESCRIPTION
Motivation
-----------
The Request error kind in reqwest is returned to us when the client fails to write a request to the network. These errors should be retried.

Changes
--------
Add a SendRequest ErrorKind to httpx Error which is created when reqwest returns us a Request error kind.
Update httpx based packages to wrap the httpx error where relevent. Retry on SendRequest ErrorKind.