### PR TITLE
RSCBC-235: Convert various callbacks to use channels

### DIFF
--- a/sdk/couchbase-core/src/kvclient_ops.rs
+++ b/sdk/couchbase-core/src/kvclient_ops.rs
@@ -367,7 +367,7 @@ where
             Err(e) => {
                 if let memdx::error::ErrorKind::Dispatch { .. } = e.kind() {
                     info!("Client {} closing due to dispatch error", &self.id);
-                    self.mark_closed().await;
+                    let _ = self.close().await;
                 }
 
                 Err(MemdxError::new(e)
@@ -384,7 +384,7 @@ where
                 if let memdx::error::ErrorKind::Server(se) = e.kind() {
                     if se.kind() == &memdx::error::ServerErrorKind::AuthStale {
                         info!("Client {} closing due to auth stale status", &self.id);
-                        self.mark_closed().await;
+                        let _ = self.close().await;
                     }
                 }
                 Err(MemdxError::new(e)

--- a/sdk/couchbase-core/src/kvendpointclientmanager.rs
+++ b/sdk/couchbase-core/src/kvendpointclientmanager.rs
@@ -28,7 +28,7 @@ use crate::results::diagnostics::EndpointDiagnostics;
 use arc_swap::ArcSwap;
 use futures::future::join_all;
 use futures::AsyncWriteExt;
-use log::{debug, error};
+use log::{debug, error, info, trace};
 use std::collections::HashMap;
 use std::future::Future;
 use std::marker::PhantomData;
@@ -282,7 +282,7 @@ where
 
             let handle = async move {
                 let pool_id = pool.id();
-                debug!("Pinging pool {pool_id}");
+                trace!("Pinging pool {pool_id}");
                 (endpoint, pool.ping_all_clients(req).await)
             };
 
@@ -319,5 +319,15 @@ where
         }
 
         Ok(clients)
+    }
+}
+
+impl<P, K> Drop for StdKvEndpointClientManager<P, K>
+where
+    P: KvClientPool<Client = K>,
+    K: KvClient,
+{
+    fn drop(&mut self) {
+        info!("Dropping StdKvEndpointClientManager {}", self.id);
     }
 }

--- a/sdk/couchbase-core/src/memdx/dispatcher.rs
+++ b/sdk/couchbase-core/src/memdx/dispatcher.rs
@@ -18,25 +18,25 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use futures::future::BoxFuture;
-
 use crate::memdx::client::ResponseContext;
 use crate::memdx::connection::ConnectionType;
 use crate::memdx::error::Result;
 use crate::memdx::packet::{RequestPacket, ResponsePacket};
 use crate::memdx::pendingop::ClientPendingOp;
 use crate::orphan_reporter::OrphanContext;
+use async_trait::async_trait;
+use futures::future::BoxFuture;
+use tokio::sync::oneshot;
 
 pub type UnsolicitedPacketHandler =
     Arc<dyn Fn(ResponsePacket) -> BoxFuture<'static, ()> + Send + Sync>;
 pub type OrphanResponseHandler = Arc<dyn Fn(ResponsePacket, OrphanContext) + Send + Sync>;
-pub type OnReadLoopCloseHandler = Arc<dyn Fn() -> BoxFuture<'static, ()> + Send + Sync>;
+pub type OnReadLoopCloseHandler = oneshot::Sender<()>;
 
 pub struct DispatcherOptions {
     pub unsolicited_packet_handler: UnsolicitedPacketHandler,
     pub orphan_handler: Option<OrphanResponseHandler>,
-    pub on_read_close_handler: OnReadLoopCloseHandler,
+    pub on_read_close_tx: OnReadLoopCloseHandler,
     pub disable_decompression: bool,
     pub id: String,
 }

--- a/sdk/couchbase-core/src/ondemand_agentmanager.rs
+++ b/sdk/couchbase-core/src/ondemand_agentmanager.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use futures::executor::block_on;
-use log::debug;
+use log::{debug, info};
 use tokio::sync::{Mutex, Notify};
 
 use crate::agent::Agent;
@@ -149,5 +149,11 @@ impl OnDemandAgentManager {
         notif.notify_waiters();
 
         Ok(())
+    }
+}
+
+impl Drop for OnDemandAgentManager {
+    fn drop(&mut self) {
+        info!("Dropping OnDemandAgentManager");
     }
 }

--- a/sdk/couchbase/src/cluster.rs
+++ b/sdk/couchbase/src/cluster.rs
@@ -31,6 +31,7 @@ use crate::options::diagnostic_options::{DiagnosticsOptions, PingOptions, WaitUn
 use crate::options::query_options::QueryOptions;
 use crate::results::diagnostics::{DiagnosticsResult, PingReport};
 use crate::results::query_results::QueryResult;
+use log::info;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -114,5 +115,11 @@ impl Cluster {
     // are created.
     pub async fn set_authenticator(&self, authenticator: Authenticator) -> error::Result<()> {
         self.client.set_authenticator(authenticator).await
+    }
+}
+
+impl Drop for Cluster {
+    fn drop(&mut self) {
+        info!("Dropping Cluster");
     }
 }


### PR DESCRIPTION
Motivation
----------
In several places we use Arcs and callbacks together. This can lead to the Drop chain being blocked as there are strong references to the Arcs within these callbacks.