### PR TITLE
RSCBC-282: Failed to read frame warning needs more context

### DIFF
--- a/sdk/couchbase-core/src/memdx/error.rs
+++ b/sdk/couchbase-core/src/memdx/error.rs
@@ -187,7 +187,11 @@ impl PartialEq for ErrorImpl {
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.inner.kind)
+        write!(f, "{}", self.inner.kind)?;
+        if let Some(source) = &self.inner.source {
+            write!(f, ": {source}")?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Changes
----------
- Add details of source error to the `Display` implementation of a memdx error, if there is one