### PR TITLE
RSCBC-285: create_index cannot index nested fields properly

### DIFF
--- a/sdk/couchbase-core/src/queryx/query.rs
+++ b/sdk/couchbase-core/src/queryx/query.rs
@@ -348,11 +348,7 @@ impl<C: Client> Query<C> {
             build_keyspace(opts.bucket_name, &opts.scope_name, &opts.collection_name)
         ));
 
-        let mut encoded_fields: Vec<String> = Vec::with_capacity(opts.fields.len());
-        for field in opts.fields {
-            encoded_fields.push(encode_identifier(field));
-        }
-        qs.push_str(&format!(" ( {})", encoded_fields.join(",")));
+        qs.push_str(&format!(" ({})", opts.fields.join(",")));
 
         let mut with: HashMap<&str, Value> = HashMap::new();
 

--- a/sdk/couchbase/tests/query.rs
+++ b/sdk/couchbase/tests/query.rs
@@ -222,9 +222,22 @@ fn test_query_indexes() {
         )
         .await;
 
+        manager
+            .create_index(
+                "test_index_nested".to_string(),
+                vec![
+                    "d.firstName".to_string(),
+                    "d.permissions.`/admin/role`".to_string(),
+                    "`d.firstName`".to_string(),
+                ],
+                opts.clone(),
+            )
+            .await
+            .unwrap();
+
         let indexes = manager.get_all_indexes(None).await.unwrap();
 
-        assert_eq!(2, indexes.len());
+        assert_eq!(3, indexes.len());
 
         let primary_index = indexes.iter().find(|idx| idx.name() == "#primary").unwrap();
         assert!(primary_index.is_primary());
@@ -238,10 +251,27 @@ fn test_query_indexes() {
         assert_eq!(test_index.state(), "deferred");
         assert_eq!(test_index.keyspace(), &collection);
 
+        let nested_index = indexes
+            .iter()
+            .find(|idx| idx.name() == "test_index_nested")
+            .unwrap();
+        let nested_key = nested_index.index_key();
+        assert_eq!(3, nested_key.len());
+        assert!(nested_key[0].contains("`d`"));
+        assert!(nested_key[0].contains("`firstName`"));
+        assert!(nested_key[1].contains("`d`"));
+        assert!(nested_key[1].contains("`permissions`"));
+        assert!(nested_key[1].contains("`/admin/role`"));
+        // distinct from the nested `d`.`firstName` path above.
+        assert_eq!("`d.firstName`", nested_key[2]);
+
         manager.build_deferred_indexes(None).await.unwrap();
 
         manager
-            .watch_indexes(vec!["test_index".to_string()], None)
+            .watch_indexes(
+                vec!["test_index".to_string(), "test_index_nested".to_string()],
+                None,
+            )
             .await
             .unwrap();
 
@@ -249,6 +279,11 @@ fn test_query_indexes() {
 
         manager
             .drop_index("test_index".to_string(), None)
+            .await
+            .unwrap();
+
+        manager
+            .drop_index("test_index_nested".to_string(), None)
             .await
             .unwrap();
 


### PR DESCRIPTION
Motivation
-----------
Currently the create_index escapes the fields that are passed in, this means that a field like `d.firstName` was parsed as '\`d.firstName\`' and not '\`d\`.\`firstName\`'. This meant that it was not possible to index nested fields properly. Likewise in the case when backticks were needed in the field name itself, escaping the backticks would cause the server to return a syntax error.

Changes
----------
Stop escaping index field names and pass them as is to allow indexing nested fields

Notes
-------
This change may break anyone who was relying on the SDK escaping the index names, e.g. trying to index non-nested fields with dots in their name, or when reserved words are used, in which case backticks will have to be added to the user's field input. 